### PR TITLE
fix the Trie tests in runtest.py

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -32,7 +32,7 @@ for td in triedata:
         t0.update(k,v)
     er = t0.root.encode('hex')
     if er != y:
-        print ("Mismatch with adds only ('%s' -> '%s')" % (x, er))
+        print ("Mismatch with adds only (\"%s\" -> \"%s\")" % (x, er))
         continue
     t = trie.Trie('/tmp/trietest-'+str(random.randrange(1000000000000)))
     dummies, reals = [], []


### PR DESCRIPTION
This fixes the `trie.Trie` tests in `runtest.py` by
- adapting the code to the new test data structure and
- catching exceptions raised for root nodes with a single child (a 2-element list) and calling `encode('hex')` on their string representation.

This patch fixes issues https://github.com/ethereum/pyethereum/issues/7 and https://github.com/ethereum/pyethereum/issues/10
