### PR TITLE
changed dependency installation order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-leveldb
 ez_setup
+leveldb
 pybitcointools
 pysha3


### PR DESCRIPTION
Ubuntu Server 12.04.4 amd64

required ez_setup to be installed before leveldb
