### PR TITLE
fix exception clause in rlp.__decode()

### DIFF
--- a/rlp.py
+++ b/rlp.py
@@ -53,7 +53,7 @@ def __decode(s,pos=0):
             o.append(obj)
         return (o,pos)
     else:
-        raise Exception("byte not supported: "+fchar)
+        raise RuntimeError("byte not supported: " + str(fchar))
 
 def decode(s): return __decode(s)[0]
 

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -8,6 +8,8 @@
 """Tests related to the trie.Trie class."""
 
 
+import py
+import pytest
 import rlp
 import utils
 
@@ -28,3 +30,13 @@ class TestRLP:
             assert expected == actual, (
                 "RLPDecode mismatch for sample '%s'; expected='%s' - "
                 "actual='%s'" % (sample, expected, actual))
+
+    def test_byte_not_supported_exception(self):
+        sample = "c6827a77c10401"
+        try:
+            rlp.decode(sample.decode('hex'))
+        except:
+            excinfo = py.code.ExceptionInfo()
+            assert "RuntimeError: byte not supported: 198" == excinfo.exconly()
+        else:
+            pytest.fail("RuntimeError not raised")


### PR DESCRIPTION
The exception clause itself has an error which results in the following failure:

```
>           raise Exception("byte not supported: "+fchar)
E           TypeError: cannot concatenate 'str' and 'int' objects
```

This branch fixes the error and uses a more meaningful exception
