### PR TITLE
added != as token in operator mapping

### DIFF
--- a/compiler/cllparser.py
+++ b/compiler/cllparser.py
@@ -112,6 +112,7 @@ precedence = {
     '&&': 6,
     'or': 7,
     '||': 7,
+    '!=': 8,
 }
 
 def toktype(token):


### PR DESCRIPTION
I'm not sure if just adding a new token with an incremented opcode value is the right approach here but I figured I could open a pull request and update my commit with any feedback. The goal is to get the following simple data feed contract compiling:

```
if tx.sender != 'feedowner':
    stop
contract.storage[tx.data[0]] = tx.data[1]
```
