### PR TITLE
Add an optional buildout.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 /dist/
 /*.egg-info/
 /.tox/
+/bin/
+/develop-eggs/
+.installed.cfg

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,31 @@ Python2.7 is required.
 
 pip install -r requirements.txt
 
+
+Buildout
+==========
+You can have dependencies managed by `buildout <http://buildout.org>`_ -- 
+a ``buildout.cfg`` is already included in the project. 
+
+Bootstrap:
+-----------
+In order to do so, you'll need to bootstrap the project (needs only be
+done once). On systems that provide ``curl`` you can use the following handy
+one-liner:
+
+``curl http://downloads.buildout.org/2/bootstrap.py | python``
+
+Otherwise download the `bootstrap script <http://downloads.buildout.org/2/bootstrap.py>`_
+into the project folder and call ``python bootstrap.py``.
+
+Building:
+----------
+Build the project via ``bin/buildout``.
+
+This will install dependencies in a virtualenv, provide you with a scoped ``python``
+interpreter (``bin/python``) and make all console_scripts available in the
+``bin`` directory (e.g. ``bin/behave`` in order to run tests).
+
 To Do
 =========
 
@@ -20,7 +45,7 @@ For Developer
     Tips for writing test code for behave
 
         1. write test scenario in *xxx.feature*
-        2. run `behave`, then behave will report the newly written scenario are
+        2. run ``behave``, then behave will report the newly written scenario are
            not implemented, and code skeleton for the corresponding steps will
            also be generated.
         3. copy & copy the generated code skeleton in a file in the *steps*

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,71 @@
+[buildout]
+
+# This fixes https://code.google.com/p/py-leveldb/issues/detail?id=33
+index = http://pypi.pediapress.com/simple/
+
+develop =
+    .
+
+parts =
+    python
+    ipython
+    console_scripts
+
+show-picked-versions = true
+newest = false
+
+eggs =
+    pyethereum
+    behave
+
+[console_scripts]
+recipe = zc.recipe.egg
+dependent-scripts = true
+eggs =
+    ${buildout:eggs}
+
+[python]
+recipe = zc.recipe.egg
+eggs =
+    ${buildout:eggs}
+interpreter = python
+
+[ipython]
+recipe = zc.recipe.egg
+eggs =
+   ipython
+   ${buildout:eggs}
+scripts = ipython
+initialization = __import__("os", level=0).environ.pop("VIRTUAL_ENV", None)
+
+[versions]
+zc.buildout = 2.2.1
+ipython = 1.1.0
+zc.recipe.egg = 2.0.1
+behave = 1.2.4
+parse = 1.6.3
+parse-type = 0.3.4
+
+# Required by:
+# pyethereum==0.0.0
+leveldb = 0.191
+
+# Required by:
+# pyethereum==0.0.0
+pybitcointools = 1.1
+
+# Required by:
+# pyethereum==0.0.0
+pysha3 = 0.3
+
+# Required by:
+# zc.recipe.egg==2.0.1
+setuptools = 2.1
+
+# Required by:
+# parse-type==0.3.4
+enum34 = 0.9.23
+
+# Required by:
+# behave==1.2.4
+six = 1.3.0


### PR DESCRIPTION
This adds a buildout.cfg for reliable builds via http://buildout.org
Apart from said file, this is purely optional; installation via
pip and setup.py is still supported.

Benefits of using buildout are:
reliable and reproducable builds, project scoped virtualenv/python/ipython,
management of dependencies and console_scripts, ...
