### PR TITLE
(closes #66) - STATEDB_DIR is not defined

### DIFF
--- a/pyethereum/blocks.py
+++ b/pyethereum/blocks.py
@@ -5,6 +5,7 @@ from trie import Trie
 from utils import big_endian_to_int as decode_int
 from utils import int_to_big_endian as encode_int
 from utils import sha3, get_db_path
+from utils import STATEDB_DIR
 import utils
 import os
 import sys


### PR DESCRIPTION
fixes by importing `STATEDB_DIR` from `utils`
