### PR TITLE
Fix wire protocol mismatch on hello listen port

### DIFF
--- a/features/steps/peermanager.py
+++ b/features/steps/peermanager.py
@@ -464,7 +464,7 @@ def step_impl(context):
 def step_impl(context):
     from pyethereum.utils import big_endian_to_int as idec
     decoded_packet = context.packeter.load_packet(context.packet)[1][3]
-    port = idec(decoded_packet[3])
+    port = idec(decoded_packet[4])
     node_id = decoded_packet[5]
     assert(context.peer.port == port)
     assert(context.peer.node_id == node_id)

--- a/pyethereum/packeter.py
+++ b/pyethereum/packeter.py
@@ -143,8 +143,6 @@ class Packeter(object):
         return packet
 
     def dump_Hello(self):
-        # inconsistency here!
-        # spec says CAPABILITIES, LISTEN_PORT but code reverses
         """
         [0x00, PROTOCOL_VERSION, NETWORK_ID, CLIENT_ID, CAPABILITIES,
         LISTEN_PORT, NODE_ID]
@@ -173,8 +171,8 @@ class Packeter(object):
                 self.PROTOCOL_VERSION,
                 self.NETWORK_ID,
                 self.CLIENT_ID,
-                self.config.getint('network', 'listen_port'),
                 self.CAPABILITIES,
+                self.config.getint('network', 'listen_port'),
                 self.NODE_ID
                 ]
         return self.dump_packet(data)


### PR DESCRIPTION
The port number of connected peers appears to be invalid when calling http://127.0.0.1:30203/api/v0alpha/peers/connected

Example response:

```
{
  peers: [
    {
      ip: "54.72.69.180",
      node_id: "bad7236033711b88406656b5947c2f2c4d0e28d5445440982608934645d0ef704f1cf2a62847a5ed1af21b99bbd07eded305848fc00409a81276defaeaba46e5",
      port: 1
    }
  ]
}
```

Expected would be port 30303 instead of 1.

This exposes a protocol mismatch on processing the `hello` peer listen port. `pyethereum` was reading the `CAPABILITIES` field instead of `LISTEN_PORT`.
