### PR TITLE
Add instruction to run setup.py to install python libraries globally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ dev_requirements
 To install the dependencies necessary for development (testing, ...), run::
 
     pip install -r dev_requirements.txt
+    python setup.py install
 
 Coding
 +++++++


### PR DESCRIPTION
Had trouble running the serpent tutorials, ran into error: `ImportError: No module named pyethereum`.  Running setup.py fixes that. 