### PR TITLE
Add easy testing for EVM contracts

### DIFF
--- a/pyethereum/tester.py
+++ b/pyethereum/tester.py
@@ -51,8 +51,11 @@ class state():
         shutil.rmtree(self.temp_data_dir)
 
     def contract(self, code, sender=k0, endowment=0):
-        sendnonce = self.block.get_nonce(u.privtoaddr(sender))
         evm = serpent.compile(code)
+        return self.evm(evm, sender, endowment)
+
+    def evm(self, evm, sender=k0, endowment=0):
+        sendnonce = self.block.get_nonce(u.privtoaddr(sender))
         tx = t.contract(sendnonce, 1, gas_limit, endowment, evm)
         tx.sign(sender)
         (s, a) = pb.apply_transaction(self.block, tx)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from pyethereum import tester
+import serpent
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(message)s')
 logger = logging.getLogger()
@@ -19,6 +20,18 @@ pblogger.log_json = False        # generate machine readable output
 
 gasprice = 0
 startgas = 10000
+
+
+# Test EVM contracts
+serpent_code = 'return(msg.data[0] ^ msg.data[1])'
+evm_code = serpent.compile(serpent_code)
+
+def test_evm():
+    s = tester.state()
+    c = s.evm(evm_code)
+    o = s.send(tester.k0, c, 0, [2, 5])
+    assert o == [32]
+
 
 # Test serpent compilation of variables using _with_, doing a simple
 # arithmetic calculation 20 * 30 + 10 = 610


### PR DESCRIPTION
Currently, `tester.state#contract()` allows creating contracts easily
with Serpent code. This adds a new method `tester.state#evm()` for
creating contracts in the same way with arbitrary EVM code.
