### PR TITLE
Adding some utilty functions like `t.sha3`, `t.u256_to_string`, `t.string_to_u256`

### DIFF
--- a/pyethereum/tester.py
+++ b/pyethereum/tester.py
@@ -121,5 +121,24 @@ def enable_logging():
 
 gas_limit = 100000
 
+# Additional functions.
 def sha3(data):
     return serpent.decode_datalist(u.sha3(serpent.encode_datalist(*data)))[0]
+
+
+def string_to_u256(str):
+    s,f = 0, 1
+    for i in range(len(str)):
+        s += f*ord(str[len(str)-i-1])
+        f *= 256
+    for i in range(32 - len(str)): # Right pad instead of left.
+        s *= 256;
+    return s
+
+
+def u256_to_string(i):
+    s = []
+    while i > 0:
+        s += chr(i%256)
+        i /=256
+    return "".join(reversed(s))

--- a/pyethereum/tester.py
+++ b/pyethereum/tester.py
@@ -120,3 +120,6 @@ def enable_logging():
 
 
 gas_limit = 100000
+
+def sha3(data):
+    return serpent.decode_datalist(u.sha3(serpent.encode_datalist(*data)))[0]

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -422,8 +422,9 @@ def test_sha3():
     from random import randrange
     s = tester.state()
     c = s.contract(sha3_code)
-    data = map(lambda _: randrange(2**256), range(randrange(0, 5)))
-    H_data = tester.sha3(data)
-    result = s.send(tester.k0, c, 0, data)
-    assert len(result) == 1
-    assert H_data == (result[0] + 2**256 if result[0] < 0 else result[0])
+    for n in range(5):
+        data = map(lambda _: randrange(2**256), range(n))
+        H_data = tester.sha3(data)
+        result = s.send(tester.k0, c, 0, data)
+        assert len(result) == 1
+        assert H_data == (result[0] + 2**256 if result[0] < 0 else result[0])

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -407,3 +407,23 @@ def test_array3():
     s = tester.state()
     c = s.contract(array_code3)
     assert [0,0,0] == s.send(tester.k0, c, 0, [])
+
+sha3_code = """
+args = array(msg.datasize)
+i = 0
+while i < msg.datasize:
+    args[i] = msg.data[i]
+    i = i + 1
+
+return(sha3(args, msg.datasize))
+"""
+
+def test_sha3():
+    from random import randrange
+    s = tester.state()
+    c = s.contract(sha3_code)
+    data = map(lambda _: randrange(2**256), range(randrange(0, 5)))
+    H_data = tester.sha3(data)
+    result = s.send(tester.k0, c, 0, data)
+    assert len(result) == 1
+    assert H_data == (result[0] + 2**256 if result[0] < 0 else result[0])

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,0 +1,8 @@
+from pyethereum import tester
+from random import randrange
+
+def test_u256_string_bijection(values=None, n=None):
+    if values is None:
+        values = map(lambda x: randrange(2**256), range(10 if n is None else n))
+    for v in values:
+        assert tester.string_to_u256(tester.u256_to_string(v)) == v


### PR DESCRIPTION
They have some tests too. The name of the latter two could be better. Helper functions fill some holes in [this wiki page](https://github.com/ethereum/pyethereum/wiki/Using-pyethereum.tester) describing the functions interesting for testing. (#159 for reference)

Btw, `x-2**256 if x > 2**255 else x` in "`s.send`" could be like something that bites people as unexpected? (hmm if it stays i should mention it in the wiki page)