### PR TITLE
Rewrite of ethclient.py

### DIFF
--- a/pyethereum/apiserver.py
+++ b/pyethereum/apiserver.py
@@ -179,7 +179,7 @@ def get_transaction_and_block(arg=None):
     except TypeError:
         bottle.abort(500, 'No hex  %s' % arg)
     try:  # index
-        tx, blk = chain_manager.index.get_transaction(tx_hash)
+        tx, blk, _ = chain_manager.index.get_transaction(tx_hash)
     except KeyError:
         # try miner
         txs = chain_manager.miner.get_transactions()

--- a/pyethereum/ethclient.py
+++ b/pyethereum/ethclient.py
@@ -1,60 +1,30 @@
-
-#!/usr/bin/env python
-import sys
-import requests
+import codecs
+from functools import wraps
 import json
-from docopt import docopt
-import utils
-import transactions
+
+from bitcoin import decode_privkey, encode_privkey
+import click
+import requests
+from requests.exceptions import ConnectionError
+
 import rlp
+from transactions import Transaction, contract
+import utils
 from . import __version__
 from . config import read_config
 
-config = read_config()
 
-api_path = config.get('api', 'api_path')
-assert api_path.startswith('/') and not api_path.endswith('/')
-
-DEFAULT_HOST = config.get('api', 'listen_host')
-DEFAULT_PORT = config.getint('api', 'listen_port')
 DEFAULT_GASPRICE = 10**12
 DEFAULT_STARTGAS = 10000
-
-def sha3(x):
-    return utils.sha3(x).encode('hex')
-
-
-def privtoaddr(x):
-    if len(x) == 64:
-        x = x.decode('hex')
-    return utils.privtoaddr(x)
-
-
-def mktx(nonce, gasprice, startgas, to, value, data):
-    return transactions.Transaction(
-        int(nonce), gasprice, startgas, to, int(value), data.decode('hex')
-    ).hex_serialize(False)
-
-
-def contract(nonce, gasprice, startgas, value, code):
-    return transactions.contract(
-        int(nonce), gasprice, startgas, int(value), code.decode('hex')
-    ).hex_serialize(False)
-
-
-def sign(txdata, key):
-    return transactions.Transaction.hex_deserialize(txdata).sign(key).hex_serialize(True)
-
 
 
 class APIClient(object):
 
-    def __init__(self, host, port):
+    def __init__(self, host, port, path):
         self.host = host
         self.port = port
-        assert api_path.startswith('/') and not api_path.endswith('/')
-        self.base_url = "http://%s:%d%s" % (host, port, api_path)
-
+        assert path.startswith('/') and not path.endswith('/')
+        self.base_url = "http://%s:%d%s" % (host, port, path)
 
     def json_get_request(self, path):
         assert path.startswith('/')
@@ -71,7 +41,8 @@ class APIClient(object):
         return self.json_get_request(path='/accounts/%s' % address)
 
     def getbalance(self, address):
-        return int(self.account_to_dict(address)['balance'])
+        account = self.account_to_dict(address)
+        return int(account['balance'])
 
     def getcode(self, address):
         return self.account_to_dict(address)['code']
@@ -87,24 +58,25 @@ class APIClient(object):
         return self.account_to_dict(address)['storage']
 
     def applytx(self, txdata):
-        tx = transactions.Transaction.hex_deserialize(txdata)
         url = self.base_url + '/transactions/'
         #print 'PUT', url, txdata
-        r = requests.put(url, txdata)
+        r = requests.put(url, codecs.encode(txdata, 'hex'))
         return dict(status_code=r.status_code, reason=r.reason, url=r.url)
 
     def quicktx(self, gasprice, startgas, to, value, data, pkey_hex):
-        nonce = self.getnonce(privtoaddr(pkey_hex))
-        tx = mktx(nonce, gasprice, startgas, to, value, data)
-        return self.applytx(sign(tx, pkey_hex))
+        nonce = self.getnonce(utils.privtoaddr(pkey_hex))
+        tx = Transaction(nonce, gasprice, startgas, to, value, str(data))
+        tx.sign(pkey_hex)
+        return self.applytx(tx.serialize(True))
 
     def quickcontract(self, gasprice, startgas, value, code, pkey_hex):
-        sender = privtoaddr(pkey_hex)
+        sender = utils.privtoaddr(pkey_hex)
         nonce = self.getnonce(sender)
-        tx = contract(nonce, gasprice, startgas, value, code)
+        tx = contract(nonce, gasprice, startgas, value, str(code))
+        tx.sign(pkey_hex)
         formatted_rlp = [sender.decode('hex'), utils.int_to_big_endian(nonce)]
         addr = utils.sha3(rlp.encode(formatted_rlp))[12:].encode('hex')
-        o = self.applytx(sign(tx, pkey_hex))
+        o = self.applytx(tx.serialize(True))
         o['addr'] = addr
         return o
 
@@ -142,85 +114,434 @@ class APIClient(object):
         return json.dumps(res, sort_keys=True, indent=2)
 
 
-doc = \
-"""ethclient
-
-Usage:
-  pyethclient getbalance [options] <address>
-  pyethclient getcode [options] <address>
-  pyethclient getstate [options] <address>
-  pyethclient getnonce [options] <address>
-  pyethclient quicktx [options] <to> <value> <data_hex> <pkey_hex>
-  pyethclient mktx <nonce> <to> <value> <data_hex>
-  pyethclient quicktx <to> <value> <data_hex> <pkey_hex>
-  pyethclient mkcontract <nonce> <value> <code_hex>
-  pyethclient quickcontract <value> <code_hex> <pkey_hex>
-  pyethclient applytx [options] <tx_hex>
-  pyethclient sign <tx_hex> <pkey_hex>
-  pyethclient privtoaddr <pkey_hex>
-  pyethclient sha3 <data>
-  pyethclient getblock [options] <blockid_hex_or_num>
-  pyethclient gettx [options] <txid_hex>
-  pyethclient getpending [options]
-  pyethclient trace [options] <txid_hex>
-  pyethclient tracejson [options] <txid_hex>
-  pyethclient dump [options] <tx_blk_id_hex>
-
-Options:
-  -h --help                 Show this screen
-  -v --version              Show version
-  -H --host=<host>          API server host [default: %s]
-  -p --port=<port>          API server port [default: %d]
-  -g --gasprice=<gasprice>  maximum gas price [default: %d]
-  -G --startgas=<startgas>  gas provided [default: %d]
-  -s --stdin                take arguments from stdin
-  -n --nonce                by default the next nonce is looked up
-""" % (DEFAULT_HOST, DEFAULT_PORT, DEFAULT_GASPRICE, DEFAULT_STARTGAS)
+def handle_connection_error(f):
+    """Decorator that handles `ConnectionError`s by printing the request error
+    message.
+    """
+    @wraps(f)
+    def new_f(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except ConnectionError as e:
+            msg = ('Could not establish connection to server '
+                   '{0}'.format(e.message))
+            raise click.ClickException(msg)
+    return new_f
 
 
-def main():
-    # Take arguments from stdin with -s
-    if len(sys.argv) > 1 and sys.argv[1] == '-s':
-        sys.argv = [sys.argv[0], sys.argv[2]] + \
-            sys.stdin.read().strip().split(' ') + sys.argv[3:]
-    # Get command line arguments
-    arguments = docopt(doc, version='pyethclient %s' % __version__)
-    #print(arguments)
-
-    host = arguments.get('--host') or DEFAULT_HOST
-    port = int(arguments.get('--port') or DEFAULT_PORT)
-    api = APIClient(host, port)
-
-    gasprice = int(arguments.get('--gasprice') or DEFAULT_GASPRICE)
-    startgas = int(arguments.get('--startgas') or DEFAULT_STARTGAS)
+def pass_client(f):
+    """Decorator that passes an `APIClient` instance to commands and handles
+    possible `ConnectionError`s.
+    """
+    raw_pass_client = click.make_pass_decorator(APIClient)
+    return raw_pass_client(handle_connection_error(f))
 
 
-    cmd_map = dict( getbalance=(api.getbalance, arguments['<address>']),
-                    getcode=(api.getcode,  arguments['<address>']),
-                    getstate=(api.getstate,  arguments['<address>']),
-                    getnonce=(api.getnonce,  arguments['<address>']),
-                    applytx=(api.applytx, arguments['<tx_hex>']),
-                    sha3=(sha3, arguments['<data>']),
-                    privtoaddr=(privtoaddr, arguments['<pkey_hex>']),
-                    mkcontract=(contract, arguments['<nonce>'], gasprice, startgas, arguments['<value>'], arguments['<code_hex>']),
-                    mktx=(mktx, arguments['<nonce>'], gasprice, startgas, arguments['<to>'], arguments['<value>'], arguments['<data_hex>']),
-                    quicktx=(api.quicktx, gasprice, startgas, arguments['<to>'], arguments['<value>'], arguments['<data_hex>'], arguments['<pkey_hex>']),
-                    quickcontract=(api.quickcontract, gasprice, startgas, arguments['<value>'], arguments['<code_hex>'], arguments['<pkey_hex>']),
-                    sign=(sign, arguments['<tx_hex>'], arguments['<pkey_hex>']),
-                    getblock=(api.getblock, arguments['<blockid_hex_or_num>']),
-                    gettx=(api.gettx, arguments['<txid_hex>']),
-                    trace=(api.trace, arguments['<txid_hex>']),
-                    tracejson=(api.tracejson, arguments['<txid_hex>']),
-                    dump=(api.dump, arguments['<tx_blk_id_hex>']),
-                    getpending=(api.getpending,)
-                    )
-    for k in cmd_map:
-        if arguments.get(k):
-            cmd_args = cmd_map.get(k)
-            out = cmd_args[0](*cmd_args[1:])
-            print out
-            break
+class PrivateKey(click.ParamType):
+    """A parameter type for private keys.
 
-if __name__ == '__main__':
-    main()
+    Inputs are accepted if they are valid private keys in either hex or WIF.
+    """
+    name = 'private key'
 
+    def convert(self, value, param, ctx):
+        """Convert the given private key to its integer representation."""
+        try:
+            return decode_privkey(value)
+        except Exception:
+            # unfortunately pybitcointools raises no more specific exception
+            self.fail('{} is not a valid private key'.format(value),
+                      param, ctx)
+
+
+class Binary(click.ParamType):
+    """A parameter type for binary data encoded as a hexadecimal string.
+
+    Inputs are accepted if they are either bytearrays or contain only
+    hexadecimal digits (0-9, a-f).
+    """
+    name = 'binary'
+
+    def __init__(self, size=None):
+        """
+        :param size: the expected data size in bytes, or None denoting the lack
+                     of a constraint (default).
+        """
+        super(Binary, self).__init__()
+        self.size = size
+
+    def convert(self, value, param, ctx):
+        """Convert a hex-string to a bytearray."""
+        if not isinstance(value, bytearray):  # value is raw input
+            try:
+                binary = bytearray(codecs.decode(value, 'hex'))
+            except TypeError:
+                msg = 'ill hex encoding '
+                if len(value) % 2 == 1:
+                    msg += '({} is odd length)'
+                else:
+                    msg += '({} contains non-hexadecimal digits)'
+                self.fail(msg.format(value), param, ctx)
+            else:
+                if self.size and len(binary) != self.size:  # check length
+                    msg = 'invalid size (expected {0}, got {1} bytes)'
+                    self.fail(msg.format(self.size, len(binary)))
+                else:
+                    return binary
+        else:  # value has been converted before
+            # this branch ensures idempotency as required by Click
+            return value
+
+
+class Hash(Binary):
+    """A parameter type for hashes, such as addresses, tx hashes, etc.
+
+    Inputs are checked for being well encoded in hex, but not converted to
+    bytearrays.
+
+    :param name: the name to use, defaulting to `"n-byte hash"` where `n`
+                 denotes the hash's size.
+    :param size: the expected length of the hash in bytes (default 32)
+    """
+
+    def __init__(self, name=None, size=32):
+        if name:
+            self.name = name
+        else:
+            self.name = '{0}-byte hash'.format(size)
+        if size <= 0:
+            raise ValueError('Hashes must be at least 1 byte long')
+        super(Hash, self).__init__(size)
+
+    def convert(self, value, param, ctx):
+        value = super(Hash, self).convert(value, param, ctx)
+        return codecs.encode(value, 'hex')
+
+
+ADDRESS = Hash(size=20)
+TXHASH = Hash(size=32)
+BLOCKHASH = Hash(size=32)
+PRIVKEY = PrivateKey()
+NONNEG_INT = click.IntRange(min=0)
+NONNEG_INT.name = 'integer'
+POS_INT = click.IntRange(min=1)
+POS_INT.name = 'integer'
+
+
+nonce_option = click.option('--nonce', '-n', type=NONNEG_INT, default=0,
+                            show_default=True,
+                            help='the number of transactions already sent by '
+                                 'the sender\'s account')
+
+
+gasprice_option = click.option('--gasprice', '-p', type=NONNEG_INT,
+                               default=DEFAULT_GASPRICE, show_default=True,
+                               help='the amount of ether paid for each unit '
+                                    'of gas consumed by the transaction')
+
+
+startgas_option = click.option('--startgas', '-g', type=NONNEG_INT,
+                               default=DEFAULT_STARTGAS, show_default=True,
+                               help='the maximum number of gas units the '
+                                    'transaction is allowed to consume')
+
+
+receiver_option = click.option('--to', '-t', type=ADDRESS, required=True,
+                               help='the receiving address')
+
+
+value_option = click.option('--value', '-v', type=NONNEG_INT, default=0,
+                            show_default=True,
+                            help='the amount of ether sent along with the '
+                                 'transaction')
+
+
+data_option = click.option('--data', '-d', type=Binary(), default='',
+                           help='additional hex-encoded data packed in the '
+                                'transaction [default: empty]')
+
+
+code_option = click.option('--code', '-c', type=Binary(), default='',
+                           help='the EVM code in hex-encoding [default: '
+                                'empty]')
+
+
+privkey_option = click.option('--key', '-k', type=PRIVKEY, required=True,
+                              help='the private key to sign with')
+
+
+def print_version(ctx, param, value):
+    """Callback for the version flag.
+
+    If the flag is set, print the version and exit. Otherwise do nothing.
+    """
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo('pyethclient {0}'.format(__version__))
+    ctx.exit()
+
+
+@click.group()
+@click.pass_context
+@click.option('--version', is_flag=True, is_eager=True, expose_value=False,
+              callback=print_version)
+@click.option('--host', '-H', help='API server host')
+@click.option('--port', '-p', type=POS_INT, help='API server host port')
+def ethclient(ctx, host, port):
+    """pyethclient is collection of commands allowing the interaction with a
+    running pyethereum instance.
+    """
+    config = read_config()
+    if not host:
+        host = config.get('api', 'listen_host')
+    if not port:
+        port = int(config.get('api', 'listen_port'))
+    path = config.get('api', 'api_path')
+    ctx.obj = APIClient(host, port, path)
+
+
+@ethclient.command()
+@click.argument('string')
+def sha3(string):
+    """Calculate the SHA3-256 hash of some input.
+
+    This command calculates the 256-bit SHA3 hash of STRING and prints the
+    result in hex-encoding. STRING is interpreted as a latin-1 encoded byte
+    array.
+    """
+    try:
+        byte_array = string.encode('latin1')
+    except UnicodeEncodeError:
+        raise click.BadParameter('STRING must be encoded in latin-1')
+    else:
+        click.echo(utils.sha3(byte_array).encode('hex'))
+
+
+@ethclient.command()
+@click.argument('key', type=PRIVKEY)
+def privtoaddr(key):
+    """Derive an address from a private key.
+
+    KEY must either be a raw private key in hex encoding or a WIF string.
+
+    The resulting address will be printed in hex encoding.
+    """
+    click.echo(utils.privtoaddr(encode_privkey(key, 'hex')))
+
+
+@ethclient.command()
+@nonce_option
+@gasprice_option
+@startgas_option
+@receiver_option
+@value_option
+@data_option
+def mktx(nonce, gasprice, startgas, to, value, data):
+    """Assemble an unsigned transaction.
+
+    The result is the hex representation of the transaction in RLP encoding.
+    """
+    tx = Transaction(nonce, gasprice, startgas, to, value,
+                     str(data))
+    click.echo(tx.hex_serialize(False))
+
+
+@ethclient.command()
+@nonce_option
+@gasprice_option
+@startgas_option
+@value_option
+@code_option
+def mkcontract(nonce, gasprice, startgas, value, code):
+    """Assemble a contract creating transaction.
+
+    The result is the hex representation of the transaction in RLP encoding.
+    """
+    ct = contract(nonce, gasprice, startgas, value, str(code))
+    click.echo(ct.hex_serialize(False))
+
+
+@ethclient.command()
+@click.argument('transaction', type=Binary())
+@click.argument('key', type=PRIVKEY)
+def signtx(transaction, key):
+    """Sign a previously created transaction.
+
+    TRANSACTION must be the hex encoded transaction, as for instance created
+    using mktx or mkcontract. If it has already been signed before, its
+    signature will be replaced.
+
+    KEY must be the private key to sign with, in hexadecimal encoding or WIF.
+
+    The signed transaction will be printed in hex encoding.
+    """
+    try:
+        tx = Transaction.deserialize(str(transaction))
+    except AssertionError:
+        raise click.BadParameter('Unable to deserialize TRANSACTION.')
+    tx.sign(encode_privkey(key, 'hex'))
+    click.echo(tx.hex_serialize(True))
+
+
+@ethclient.command()
+@click.argument('transaction', type=Binary())
+@pass_client
+def applytx(client, transaction):
+    """Absorb a transaction into the next block.
+
+    This command sends a transaction to the server, which will presumably
+    validate it, include it in its memory pool, and further announce it to the
+    network. The server's response will be returned.
+
+    TRANSACTION must a signed transaction in hex-encoding.
+    """
+    click.echo(client.applytx(str(transaction)))
+
+
+@ethclient.command()
+@gasprice_option
+@startgas_option
+@receiver_option
+@value_option
+@data_option
+@privkey_option
+@pass_client
+def quicktx(client, gasprice, startgas, to, value, data, key):
+    """Create and finalize a transaction.
+
+    This command is a shortcut that chains getnonce, mktx, signtx, and applytx.
+    It returns the server's response.
+    """
+    click.echo(client.quicktx(gasprice, startgas, to, value, data,
+                              encode_privkey(key, 'hex')))
+
+
+@ethclient.command()
+@gasprice_option
+@startgas_option
+@value_option
+@code_option
+@privkey_option
+@pass_client
+def quickcontract(client, gasprice, startgas, value, code, key):
+    """Create and finalize a contract.
+
+    This command is a shortcut that chains getnonce, mkcontract, signtx, and
+    applytx. In addition to the server's response, it returns the address of
+    the newly created contract.
+    """
+    click.echo(client.quickcontract(gasprice, startgas, value, code,
+                                    encode_privkey(key, 'hex')))
+
+
+@ethclient.command()
+@click.argument('address', type=ADDRESS)
+@pass_client
+def getbalance(client, address):
+    """Retrieve the balance of an account."""
+    click.echo(client.getbalance(address))
+
+
+@ethclient.command()
+@click.argument('address', type=ADDRESS)
+@pass_client
+def getcode(client, address):
+    """Print the EVM code of an account."""
+    click.echo(client.getcode(address))
+
+
+@ethclient.command()
+@click.argument('address', type=ADDRESS)
+@pass_client
+def getnonce(client, address):
+    """Return an account's nonce."""
+    click.echo(client.getnonce(address))
+
+
+@ethclient.command()
+@click.argument('address', type=ADDRESS)
+@pass_client
+def getstate(client, address):
+    """Print an account's storage contents.
+
+    The output will be hex encoded. Non-contract accounts have empty storages.
+    """
+    click.echo(client.account_to_dict(address)['storage'])
+
+
+@ethclient.command()
+@click.option('--txhash', '-t', type=TXHASH, default=None,
+              help='the hash of one transaction in the block')
+@click.option('--blockhash', '-b', type=BLOCKHASH, default=None,
+              help='the hash of the block')
+@click.option('--blocknumber', '-n', type=NONNEG_INT, default=None,
+              help='the block\'s number in the chain')
+@pass_client
+def getblock(client, txhash, blockhash, blocknumber):
+    """Fetch a block from the block chain.
+
+    The block must either be specified by its block hash, its number in the
+    chain, or by a transaction included in the block.
+    """
+    if sum(map(lambda p: p is None, (txhash, blockhash, blocknumber))) != 2:
+        raise click.BadParameter('Exactly one of the options --txhash, '
+                                 '--blockhash and --blocknumber must be '
+                                 'given.')
+    else:
+        click.echo(client.getblock(txhash or blockhash or blocknumber))
+
+
+@ethclient.command()
+@click.argument('txhash', type=TXHASH)
+@pass_client
+def gettx(client, txhash):
+    """Show a transaction from the block chain.
+
+    TXHASH must be the hex encoded hash of the transaction.
+    """
+    click.echo(client.gettx(txhash))
+
+
+@ethclient.command()
+@pass_client
+def getpending(client):
+    """List all pending transactions."""
+    click.echo(client.getpending()['transactions'])
+
+
+@ethclient.command()
+@click.argument('txhash', type=TXHASH)
+@click.option('--print/--json', 'print_', is_flag=True, default=True,
+              help='Display the trace human readably [default] or in JSON.')
+@pass_client
+def trace(client, txhash, print_):
+    """Read the trace left by a transaction.
+
+    The transaction must be specified by its hash TXHASH.
+    """
+    if print_:
+        click.echo(client.trace(txhash))
+    else:
+        click.echo(client.tracejson(txhash))
+
+
+@ethclient.command()
+@click.option('--blockhash', '-b', type=BLOCKHASH, default=None,
+              help='the hash of the block')
+@click.option('--txhash', '-t', type=TXHASH, default=None,
+              help='the hash of one transaction in the block')
+@pass_client
+def dump(client, blockhash, txhash):
+    """Dump the state of a block.
+
+    The block must be specified either by its hash or by a transaction included
+    into the block.
+
+    In addition to the result of getblock, this command also yields the state
+    of every account.
+    """
+    if sum(map(lambda p: p is not None, (blockhash, txhash))) != 1:
+        raise click.BadParameter('Either --blockhash or --txhash must be '
+                                 'specified')
+    else:
+        click.echo(client.dump(blockhash or txhash))

--- a/pyethereum/ethclient.py
+++ b/pyethereum/ethclient.py
@@ -21,7 +21,7 @@ DEFAULT_STARTGAS = 10000
 
 
 class APIClient(object):
-    """A client sending HTTP request to an :class:`APIServer`.
+    """A client sending HTTP request to an :class:`~apiserver.APIServer`.
 
     :param host: the hostname of the server
     :param port: the server port to use
@@ -39,9 +39,10 @@ class APIClient(object):
         :param method: the HTTP method to use ('GET', 'PUT', etc.)
         :param data: the data to attach to the request
         :returns: the server's JSON response deserialized to a python object
-        :raises :class:`requests.HTTPError`: if the server reports an error
-        :raises :class:`requests.ConnectionError`: if setting up the connection
-                                                   to the server failed
+        :raises: :exc:`~requests.exceptions.HTTPError` if the server reports an
+                 error
+        :raises: :exc:`~requests.exceptions.ConnectionError` if setting up the
+                 connection to the server failed
         """
         url = urljoin(self.base_url, path)
         response = requests.request(method, url, data=data)
@@ -53,10 +54,10 @@ class APIClient(object):
 
         The returned `dict` will have the following keys:
 
-        - `'nonce'`
-        - `'balance'`
-        - `'code'`
-        - `'storage'`
+        - ``'nonce'``
+        - ``'balance'``
+        - ``'code'``
+        - ``'storage'``
 
         :param address: the account's hex-encoded address
         """
@@ -68,12 +69,11 @@ class APIClient(object):
         The server will validate the transaction, add it to its list of pending
         transactions and further broadcast it to its peers.
 
-        :param tx: a :class:`Transaction`
+        :param tx: a :class:`~transactions.Transaction`
         :returns: the response from the server
-        :raises :class:`requests.HTTPError`: if the validation on the server
-                                             fails, e.g. due to a forged
-                                             signature or an invalid nonce
-                                             (status code 400).
+        :raises: :exc:`~requests.exceptions.HTTPError` if the validation on the
+                 server fails, e.g. due to a forged signature or an invalid
+                 nonce (status code 400).
         """
         txdata = tx.hex_serialize(True)
         return self.request('/transactions/', 'PUT', txdata)['transactions'][0]
@@ -83,8 +83,8 @@ class APIClient(object):
 
         :param id: the block hash, the block number, or the hash of an
                    arbitrary transaction in the block
-        :raises :class:`requests.HTTPError`: if the server can not find the
-                                             requested block (status code 404)
+        :raises: :exc:`~requests.exceptions.HTTPError` if the server can not
+                 find the requested block (status code 404)
         """
         response = self.request('/blocks/{0}'.format(id))
         return response['blocks'][0]
@@ -93,9 +93,8 @@ class APIClient(object):
         """For a given parent block, request the block hashes of its children.
 
         :param block_hash: the hash of the parent block
-        :raises :class:`requests.HTTPError`: if the server can not find a block
-                                             with the given hash (status code
-                                             404)
+        :raises: :exc:`~requests.exceptions.HTTPError`: if the server can not
+                 find a block with the given hash (status code 404)
         """
         return self.request('/blocks/{0}/children'.format(id))['children']
 
@@ -103,10 +102,9 @@ class APIClient(object):
         """Request a specific transaction.
 
         :param tx_hash: the hex-encoded transaction hash
-        :returns: a :class:`Transaction`
-        :raises :class:`requests.HTTPError`: if the server does not know about
-                                             the requested transaction (status
-                                             code 404)
+        :returns: a :class:`~transactions.Transaction`
+        :raises: :exc:`~requests.exceptions.HTTPError`: if the server does not
+                 know about the requested transaction (status code 404)
         """
         response = self.request('/transactions/{0}'.format(tx_hash))
         tx_dict = response['transactions'][0]
@@ -129,9 +127,9 @@ class APIClient(object):
         """Request the trace left by a transaction during its processing.
 
         :param tx_hash: the hex-encoded transaction hash
-        :raises :class:`requests.HTTPError`: if the server can not find the
-                                             transaction (status code 404)
-        :returns: a `list` of `dict`s, expressing the single footprints
+        :raises: :exc:`~requests.exceptions.HTTPError` if the server can not
+                 find the transaction (status code 404)
+        :returns: a list of dicts, expressing the single footprints
         """
         res = self.request('/trace/{0}'.format(tx_hash))
         return res['trace']
@@ -147,8 +145,8 @@ class APIClient(object):
 
 
 def handle_connection_errors(f):
-    """Decorator that handles `ConnectionError`s and `HTTPError`s by printing
-    an appropriate error message and exiting.
+    """Decorator that handles ConnectionErrors and HTTPErrors by printing an
+    appropriate error message and exiting.
     """
     @wraps(f)
     def new_f(*args, **kwargs):
@@ -167,8 +165,9 @@ def handle_connection_errors(f):
 
 
 def pass_client(f):
-    """Decorator that passes an `APIClient` instance to commands and handles
-    possible `ConnectionError`s.
+    """Decorator that passes a :class:`~ethclient.APIClient` instance and
+    handles unsuccessful requests as well as failed connections by printing an
+    error message.
     """
     raw_pass_client = click.make_pass_decorator(APIClient)
     return raw_pass_client(handle_connection_errors(f))

--- a/pyethereum/ethclient.py
+++ b/pyethereum/ethclient.py
@@ -117,11 +117,25 @@ class APIClient(object):
                          int(tx_dict['v']),
                          int(tx_dict['r']),
                          int(tx_dict['s']))
+        print tx_dict
         return tx
 
     def getpending(self):
         """Request a list of pending transactions."""
-        return self.request('/pending/')['transactions']
+        response = self.request('/pending/')['transactions']
+        print response
+        txs = []
+        for tx_dict in response:
+            txs.append(Transaction(int(tx_dict['nonce']),
+                                   int(tx_dict['gasprice']),
+                                   int(tx_dict['startgas']),
+                                   tx_dict['to'],
+                                   int(tx_dict['value']),
+                                   tx_dict['data'][2:],
+                                   int(tx_dict['v']),
+                                   int(tx_dict['r']),
+                                   int(tx_dict['s'])))
+        return txs
 
     def trace(self, tx_hash):
         """Request the trace left by a transaction during its processing.
@@ -558,7 +572,7 @@ def gettx(client, txhash):
 @pass_client
 def getpending(client):
     """List all pending transactions."""
-    pecho(client.getpending())
+    pecho([tx.to_dict() for tx in client.getpending()])
 
 
 @ethclient.command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bitcoin
 bottle
+click
 docopt
 ethereum-serpent
 leveldb

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ versioneer.tag_prefix = '' # tags are like 1.2.0
 versioneer.parentdir_prefix = 'pyethereum-' # dirname like 'myproject-1.2.0'
 
 console_scripts = ['pyeth=pyethereum.eth:main',
-                   'pyethclient=pyethereum.ethclient:main']
+                   'pyethclient=pyethereum.ethclient:ethclient']
 
 setup(name="pyethereum",
       packages=find_packages("."),

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name="pyethereum",
       install_requires=[
           'bitcoin',
           'bottle',
+          'click',
           'docopt',
           'ethereum-serpent',
           'leveldb',


### PR DESCRIPTION
I've noticed that the current pyethclient is looking a little rudimentary, so I've rewritten it. I've used [Click](http://click.pocoo.org): it's well documented, looks sophisticated but is easy to use, and I just love decorators.

The subcommands are still the same (I've renamed `sign` to `signtx` for consistency, though), but I've added a bunch of documentation (`ethclient --help` and `ethclient [command] --help`) and some parameter validation (addresses, private keys, and arbitrary hex strings).

As a side effect, the `APIClient` has become more seperated from the commands, so I've given it a cleaner interface (it raises exceptions instead of returning errors as dicts and deals with Transaction objects instead of serialized transactions)