### PR TITLE
Updated slogging.py to track changed name in structlog 

### DIFF
--- a/pyethereum/slogging.py
+++ b/pyethereum/slogging.py
@@ -64,11 +64,11 @@ class BoundLoggerTrace(structlog.stdlib.BoundLogger):
                 and self._processors[0].listeners:
             return True
         # log level filter
-        return self._logger.isEnabledFor(structlog.stdlib._nameToLevel[level_name])
+        return self._logger.isEnabledFor(structlog.stdlib._NAME_TO_LEVEL[level_name])
 
 
 structlog.stdlib.TRACE = TRACE = 5
-structlog.stdlib._nameToLevel['trace'] = TRACE
+structlog.stdlib._NAME_TO_LEVEL['trace'] = TRACE
 logging.addLevelName(TRACE, "TRACE")
 
 


### PR DESCRIPTION
I needed to change  _nameToLevel => _NAME_TO_LEVEL in slogging.py to run against the current github version of structlog.

This was a very naive modification -- I'm not much of a Python programmer, and I wonder whether the inverse map in structlog/stdlib.py, _LEVEL_TO_NAME might need to be updated in sync. But this was enough to my attempts to play around with Trie.py to work.