### PR TITLE
Store sender's public key in Transaction

### DIFF
--- a/ethereum/transactions.py
+++ b/ethereum/transactions.py
@@ -59,8 +59,9 @@ class Transaction(rlp.Serializable):
                 raise InvalidTransaction("Invalid signature values!")
             rlpdata = rlp.encode(self, UnsignedTransaction)
             rawhash = utils.sha3(rlpdata)
-            pub = encode_pubkey(ecdsa_raw_recover(rawhash, (self.v, self.r, self.s)), 'bin')
-            self.sender = utils.sha3(pub[1:])[-20:]
+            Q = ecdsa_raw_recover(rawhash, (self.v, self.r, self.s))
+            self.sender_pubkey = encode_pubkey(Q, 'bin')
+            self.sender = utils.sha3(self.sender_pubkey[1:])[-20:]
         else:
             self.sender = 0
 


### PR DESCRIPTION
The sender's public key is a useful piece of information, and since it is already being calculated, it doesn't make sense to throw it away.