### PR TITLE
Update `_solidity.compile_rich()` output to mirror geth

### DIFF
--- a/ethereum/tests/test_solidity.py
+++ b/ethereum/tests/test_solidity.py
@@ -1,5 +1,9 @@
+import pytest
 from ethereum import tester
 from ethereum import utils
+from ethereum._solidity import get_solidity
+
+
 serpent_contract = """
 extern solidity: [sub2:[]:i]
 
@@ -608,3 +612,54 @@ def test_ether_charging_datafeeds():
         assert c.get('moose') == 0
         assert c.get('moose', value=69) == 0
         assert c.get('moose', value=70) == 110
+
+
+compile_rich_contract = """
+contract contract_add {
+    function add7(uint a) returns(uint d) { return a + 7; }
+    function add42(uint a) returns(uint d) { return a + 42; }
+}
+contract contract_sub {
+    function subtract7(uint a) returns(uint d) { return a - 7; }
+    function subtract42(uint a) returns(uint d) { return a - 42; }
+}
+"""
+
+
+@pytest.mark.skipif(get_solidity() is None, reason="'solc' compiler not available")
+def test_solidity_compile_rich():
+    contract_info = get_solidity().compile_rich(compile_rich_contract)
+
+    import json
+    print json.dumps(contract_info)
+    assert len(contract_info) == 2
+    assert set(contract_info.keys()) == {'contract_add', 'contract_sub'}
+    assert set(contract_info['contract_add'].keys()) == {'info', 'code'}
+    assert set(contract_info['contract_add']['info'].keys()) == {
+        'language', 'languageVersion', 'abiDefinition', 'source',
+        'compilerVersion', 'developerDoc', 'userDoc'
+    }
+    assert contract_info['contract_add']['code'] == (
+        "0x606060405260ad8060116000396000f30060606040526000357c0100000000000000"
+        "00000000000000000000000000000000000000000090048063651ae239146041578063"
+        "cb02919f14606657603f565b005b6050600480359060200150608b565b604051808281"
+        "5260200191505060405180910390f35b6075600480359060200150609c565b60405180"
+        "82815260200191505060405180910390f35b60006007820190506097565b919050565b"
+        "6000602a8201905060a8565b91905056")
+    assert contract_info['contract_sub']['code'] == (
+        "0x606060405260ad8060116000396000f30060606040526000357c0100000000000000"
+        "0000000000000000000000000000000000000000009004806361752024146041578063"
+        "7aaef1a014606657603f565b005b6050600480359060200150608b565b604051808281"
+        "5260200191505060405180910390f35b6075600480359060200150609c565b60405180"
+        "82815260200191505060405180910390f35b60006007820390506097565b919050565b"
+        "6000602a8203905060a8565b91905056")
+    assert {
+        defn['name']
+        for defn
+        in contract_info['contract_add']['info']['abiDefinition']
+    } == {'add7', 'add42'}
+    assert {
+        defn['name']
+        for defn
+        in contract_info['contract_sub']['info']['abiDefinition']
+    } == {'subtract7', 'subtract42'}


### PR DESCRIPTION
`solidity.compile_rich()` is used by pyethapp's `eth_compileSolidity` JSON-RPC method. 
This commit updates it's output to be on-par with geth's.

Includes tests.

Fixes: ethereum/pyethapp#30