### PR TITLE
Allow user to specify stdin and stdout streams for solc subprocess call

### DIFF
--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -78,9 +78,9 @@ class solc_wrapper(object):
         return sorted_contracts[idx][1]['json-abi']
 
     @classmethod
-    def combined(cls, code):
+    def combined(cls, code, stdin=subprocess.PIPE, stdout=subprocess.PIPE):
         p = subprocess.Popen(['solc', '--add-std=1', '--combined-json', 'json-abi,binary,sol-abi,natspec-dev,natspec-user'],
-                             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                             stdin=stdin, stdout=stdout)
         stdoutdata, stderrdata = p.communicate(input=code)
         if p.returncode:
             raise CompileError('compilation failed')


### PR DESCRIPTION
### What was wrong?

When using the `solc_wrapper` from `ethereum._solidity` and a compilation error occurs, the details of the error get pushed to `stdout` via `subprocess.PIPE`.  This error detail often contains useful information related to the problem that needs fixing.

When writing some tooling to automate compilation that *watches* the contract source files and recompiles them on changes, I needed to catch the `CompileError` exception, print the compile error, and continue watching.  Without control over the stdout stream catching this text and outputting it myself was not possible.

### How was it fixed?

Added two new optional arguments to the `solc_wrapper.combine()` method which allow the caller to pass in their own values for `stdout` and `stdin`.

#### Cute animal picture

![dog-wearing-birthday-hat-6996159](https://cloud.githubusercontent.com/assets/824194/9425210/07a34430-48c5-11e5-943a-4b5192136fa9.jpg)
