### PR TITLE
Refactor logging

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 tox
 coveralls
 pytest
+pytest-capturelog
 pytest-timeout
 https://github.com/ethereum/serpent/tarball/develop

--- a/ethereum/tests/conftest.py
+++ b/ethereum/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+from ethereum import slogging
+
+
+@pytest.mark.hookwrapper
+def pytest_runtest_setup(item):
+    """Attach pytest-capturelog's handler to `slogging`'s root logger"""
+    yield
+    caplog_handler = getattr(item, 'capturelog_handler', None)
+    if caplog_handler and caplog_handler not in slogging.rootLogger.handlers:
+        slogging.rootLogger.addHandler(caplog_handler)
+
+
+@pytest.mark.hookwrapper
+def pytest_runtest_makereport(item, call):
+    """Remove pytest-capturelog's handler from `slogging`'s root logger"""
+    if call.when == 'call':
+        caplog_handler = getattr(item, 'capturelog_handler', None)
+        if caplog_handler and caplog_handler in slogging.rootLogger.handlers:
+            slogging.rootLogger.removeHandler(caplog_handler)
+    yield

--- a/ethereum/tests/test_logging.py
+++ b/ethereum/tests/test_logging.py
@@ -1,142 +1,75 @@
 import json
 import logging
 import logging.handlers
-import ethereum.slogging as slogging
+import pytest
+from ethereum import slogging
 
 
-class TestHandler(logging.handlers.BufferingHandler):
-
-    def __init__(self):
-        logging.Handler.__init__(self)
-        self.capacity = 10000
-        self.buffer = []
-
-    @property
-    def logged(self):
-        # returns just the message part (no formatting)
-        if len(self.buffer):
-            msg = self.buffer.pop().getMessage()
-            return msg
-        return None
-
-    def does_log(self, logcall):
-        assert self.logged is None
-        logcall('abc')
-        sl = self.logged
-        return bool(sl and 'abc' in sl)
-
-
-def get_test_handler():
-    "handler.bufffer = [] has the logged lines"
-    th = TestHandler()
-    logging.getLogger().handlers = [th]
-    ethlogger = slogging.getLogger()
-    ethlogger.handlers = [th]
-    return th
-
-
-def setup_logging(config_string='', log_json=False):
-    # setsup default logging
-    slogging.configure(config_string=config_string, log_json=log_json)
-    th = get_test_handler()
-    return th
-
-
-########## TESTS ###############
-
-def test_testhandler():
-    th = get_test_handler()
-    assert th.logged == None
-    th = setup_logging()
-    assert th.logged is None
-    log = slogging.get_logger('a')
-    log.warn('abc')
-    assert 'abc' in th.logged
-    assert th.logged is None
-    # same with does_log
-    assert th.does_log(log.warn)
-    assert not th.does_log(log.debug)
-
-
-def test_baseconfig():
-    # test default loglevel INFO
-    th = setup_logging()
+@pytest.mark.parametrize('level_name', ['critical', 'error', 'warning', 'info', 'debug', 'trace'])
+def test_basic(caplog, level_name):
+    slogging.configure(":trace")
     log = slogging.get_logger()
-    assert th.does_log(log.error)
-    assert th.does_log(log.critical)
-    assert th.does_log(log.warn)
-    assert th.does_log(log.warn)
-    assert th.does_log(log.info)
-    assert not th.does_log(log.debug)
-    assert not th.does_log(log.trace)
-    config_string = ':inFO,a:trace,a.b:debug'
-    th = setup_logging(config_string=config_string)
+    with caplog.atLevel('TRACE'):
+        getattr(log, level_name)(level_name)
+
+    assert len(caplog.records()) == 1
+    assert caplog.records()[0].levelname == level_name.upper()
+    assert level_name in caplog.records()[0].msg
 
 
-def test_is_active2():
-    setup_logging(':info')
+def test_initial_config():
+    slogging.getLogger().handlers = []
+    slogging.configure()
+    assert len(slogging.getLogger().handlers) == 1
+    assert isinstance(slogging.getLogger().handlers[0], logging.StreamHandler)
+
+
+def test_is_active():
+    slogging.configure()
     tester = slogging.get_logger('tester')
     assert tester.is_active(level_name='info')
     assert not tester.is_active(level_name='trace')
 
 
-def test_lvl_trace():
-    config_string = ':trace'
-    th = setup_logging(config_string=config_string)
-    log = slogging.get_logger()
-    assert th.does_log(log.debug)
-    assert th.does_log(log.trace)
-
-def test_jsonconfig():
-    th = setup_logging(log_json=True)
+def test_jsonconfig(caplog):
+    slogging.configure(log_json=True)
     log = slogging.get_logger('prefix')
     log.warn('abc', a=1)
-    assert json.loads(th.logged) == dict(event='prefix.abc', a=1)
+    assert json.loads(caplog.records()[0].msg) == dict(event='prefix.abc', a=1)
 
 
-def test_kvprinter():
-    # we can not test formatting
+def test_configuration():
     config_string = ':inFO,a:trace,a.b:debug'
-    th = setup_logging(config_string=config_string)
-    # log level info
-    log = slogging.get_logger('foo')
-    log.info('baz', arg=2)
-    l = th.logged
-    assert 'baz' in l
-
-
-def test_namespaces():
-    config_string = ':inFO,a:trace,a.b:debug'
-    th = setup_logging(config_string=config_string)
-    # log level info
+    slogging.configure(config_string=config_string)
     log = slogging.get_logger()
     log_a = slogging.get_logger('a')
     log_a_b = slogging.get_logger('a.b')
-    assert th.does_log(log.info)
-    assert not th.does_log(log.debug)
-    assert th.does_log(log_a.trace)
-    assert th.does_log(log_a_b.debug)
-    assert not th.does_log(log_a_b.trace)
+    assert log.is_active('info')
+    assert not log.is_active('debug')
+    assert log_a.is_active('trace')
+    assert log_a_b.is_active('debug')
+    assert not log_a_b.is_active('trace')
 
 
-def test_tracebacks():
-    th = setup_logging()
+def test_tracebacks(caplog):
+    slogging.configure()
     log = slogging.get_logger()
 
     def div(a, b):
         try:
-            r = a / b
+            _ = a / b
             log.error('heres the stack', stack_info=True)
         except Exception as e:
             log.error('an Exception trace should preceed this msg', exc_info=True)
     div(1, 0)
-    assert 'an Exception' in th.logged
+    assert 'an Exception trace' in caplog.text()
+    assert 'Traceback' in caplog.text()
     div(1, 1)
-    assert 'the stack' in th.logged
+    assert 'the stack' in caplog.text()
 
 
-def test_listeners():
-    th = setup_logging()
+def test_listeners(caplog):
+    slogging.configure()
     log = slogging.get_logger()
 
     called = []
@@ -144,58 +77,29 @@ def test_listeners():
     def log_cb(event_dict):
         called.append(event_dict)
 
-    # handler for handling listiners
-    exec_handler = slogging.ExecHandler()
-    exec_handler.setLevel(logging.TRACE)
-    log.addHandler(exec_handler)
-
     # activate listener
-    slogging.log_listeners.listeners.append(log_cb) # Add handlers
+    slogging.log_listeners.append(log_cb)  # Add handlers
     log.error('test listener', abc='thislistener')
-    assert 'thislistener' in th.logged
+    assert 'thislistener' in caplog.text()
     r = called.pop()
     assert r == dict(event='test listener', abc='thislistener')
 
-    log.trace('trace is usually filtered', abc='thislistener') # this handler for function log_cb does not work
-    assert th.logged is None
+    log.trace('trace is usually filtered', abc='thislistener')  # this handler for function log_cb does not work
+    assert "trace is usually filtered" not in caplog.text()
 
     # deactivate listener
-    slogging.log_listeners.listeners.remove(log_cb)
+    slogging.log_listeners.remove(log_cb)
     log.error('test listener', abc='nolistener')
-    assert 'nolistener' in th.logged
+    assert 'nolistener' in caplog.text()
     assert not called
 
 
 def test_logger_names():
-    th = setup_logging()
-    names = set(['a', 'b', 'c'])
+    slogging.configure()
+    names = {'a', 'b', 'c'}
     for n in names:
         slogging.get_logger(n)
     assert names.issubset(set(slogging.get_logger_names()))
-
-
-def test_is_active():
-    th = setup_logging()
-    log = slogging.get_logger()
-    assert not log.is_active('trace')
-    assert not log.is_active('debug')
-    assert log.is_active('info')
-    assert log.is_active('warn')
-
-    # activate w/ listner
-    slogging.log_listeners.listeners.append(lambda x: x)
-
-    exec_handler = slogging.ExecHandler()
-    exec_handler.setLevel(logging.TRACE)
-    log.addHandler(exec_handler)
-
-    for i in log.handlers:
-        if isinstance(i, slogging.ExecHandler):
-            i.setLevel(logging.TRACE)
-            exechandler = i
-    assert slogging.checkLevel(exechandler, 'trace')
-    slogging.log_listeners.listeners.pop()
-    assert not log.is_active('trace')
 
 
 def test_lazy_log():
@@ -214,17 +118,17 @@ def test_lazy_log():
             called_print.append(1)
             return 'expensive data preparation'
 
-    th = setup_logging(log_json=True)
+    slogging.configure(log_json=True)
     log = slogging.get_logger()
     log.trace('no', data=Expensive())
     assert not called_print
-    log.info('yes', data=Expensive()) # !!!!!!!!!!!!!
+    log.info('yes', data=Expensive())  # !!!!!!!!!!!!!
     assert called_print.pop()
 
 
 def test_get_configuration():
     root_logger = slogging.getLogger()
-    root_logger.manager.loggerDict = {} # clear old loggers
+    root_logger.manager.loggerDict = {}  # clear old loggers
     config_string = ':INFO,a:TRACE,a.b:DEBUG'
     log_json = False
     slogging.configure(config_string=config_string, log_json=log_json)
@@ -249,39 +153,34 @@ def test_get_configuration():
     assert set(config['config_string'].split(',')) == set(config_string.split(','))
 
 
-def test_recorder():
-    th = setup_logging(log_json=True)
+def test_recorder(caplog):
+    slogging.configure(log_json=True)
     log = slogging.get_logger()
-
-    exec_handler = slogging.ExecHandler(log_json=log.log_json)
-    exec_handler.setLevel(logging.TRACE)
-    log.addHandler(exec_handler)
 
     # test info
     recorder = slogging.LogRecorder()
-    assert len(slogging.log_listeners.listeners) == 1
+    assert len(slogging.log_listeners) == 1
     log.info('a', v=1)
-    assert th.logged
+    assert "a" in caplog.text()
     r = recorder.pop_records()
     assert r[0] == dict(event='a', v=1)
-    assert len(slogging.log_listeners.listeners) == 0
+    assert len(slogging.log_listeners) == 0
 
     # test trace
     log.setLevel(logging.TRACE)
     recorder = slogging.LogRecorder()
-    assert len(slogging.log_listeners.listeners) == 1
-    log.trace('a', v=1)
-    assert th.logged
+    assert len(slogging.log_listeners) == 1
+    log.trace('a', v=2)
+    assert '"v": 2' in caplog.text()
     r = recorder.pop_records()
-    assert r[0] == dict(event='a', v=1)
-    assert len(slogging.log_listeners.listeners) == 0
+    assert r[0] == dict(event='a', v=2)
+    assert len(slogging.log_listeners) == 0
 
 
 def test_howto_use_in_tests():
     # select what you want to see.
     # e.g. TRACE from vm except for pre_state :DEBUG otherwise
-    config_string = ':DEBUG,eth.vm:TRACE,vm.pre_state:INFO'
-    slogging.configure(config_string=config_string)
+    slogging.configure(':DEBUG,eth.vm:TRACE,vm.pre_state:INFO')
     log = slogging.get_logger('tests.logging')
     log.info('test starts')
 
@@ -290,8 +189,7 @@ def test_how_to_use_as_vm_logger():
     """
     don't log until there was an error
     """
-    config_string = ':DEBUG,eth.vm:INFO'
-    slogging.configure(config_string=config_string)
+    slogging.configure(':DEBUG,eth.vm:INFO')
     log = slogging.get_logger('eth.vm')
 
     # record all logs
@@ -310,184 +208,106 @@ def test_how_to_use_as_vm_logger():
             log.info(x.pop('event'), **x)
 
 
-def test_cleanup():
-    config_string = ':debug'
-    slogging.configure(config_string=config_string)
+@pytest.mark.parametrize(
+    ('logger_name', 'filter', 'should_log'),
+    [
+        ('a', None, True),
+        ('a.a', 'a', True),
+        ('a.a', 'a.a', True),
+        ('a.a', 'b', False),
 
-def test_logger_filter():
-    th = setup_logging()
-    log_a = slogging.get_logger("a")
-    log_a.info("log_a", v=1)
-    assert "log_a" in th.logged
+    ])
+def test_logger_filter(caplog, logger_name, filter, should_log):
+    slogging.configure()
+    log = slogging.get_logger(logger_name)
+    if filter:
+        log.addFilter(logging.Filter(filter))
+    log.info("testlogmessage", v=1)
+    if should_log:
+        assert "testlogmessage" in caplog.text()
+    else:
+        assert "testlogmessage" not in caplog.text()
 
-    log_a_a = slogging.get_logger("a.a")
-    log_a_a.info("log_a_a", v=1)
-    assert "log_a_a" in th.logged
 
-    log_a.addFilter(logging.Filter("log_a"))
-    log_a.info("log", v=1)
-    assert not th.logged
-    log_a_a.info("log_a_a", v=1)
-    assert th.logged
+def test_bound_logger(caplog):
+    slogging.configure(config_string=':trace')
+    real_log = slogging.getLogger()
 
-    log_a.removeFilter("log_a")
-    log_a.addFilter("log_a_a")
-    log_a.info("log_a mes", v=1)
-    assert not th.logged
-    log_a_a.info("log_a_a mes", v=1)
-    assert "log_a_a mes" in th.logged
+    bound_log_1 = real_log.bind(key1="value1")
+    with caplog.atLevel(slogging.TRACE):
+        bound_log_1.info("test1")
+        assert "test1" in caplog.text()
+        assert "key1=value1" in caplog.text()
 
-class TestFilter(logging.Filter):
+    bound_log_2 = bound_log_1.bind(key2="value2")
+    with caplog.atLevel(slogging.TRACE):
+        bound_log_2.info("test2")
+        assert "test2" in caplog.text()
+        assert "key1=value1" in caplog.text()
+        assert "key2=value2" in caplog.text()
+
+
+def test_bound_logger_isolation(caplog):
     """
-    This is test class for filter record in logger
+    Ensure bound loggers don't "contaminate" their parent
     """
-    def filter(self, record):
-        if "filtering!" in record.msg:
-            return True
-        else:
-            return False
+    slogging.configure(config_string=':trace')
+    real_log = slogging.getLogger()
+
+    bound_log_1 = real_log.bind(key1="value1")
+    with caplog.atLevel(slogging.TRACE):
+        bound_log_1.info("test1")
+        records = caplog.records()
+        assert len(records) == 1
+        assert "test1" in records[0].msg
+        assert "key1=value1" in records[0].msg
+
+    with caplog.atLevel(slogging.TRACE):
+        real_log.info("test2")
+        records = caplog.records()
+        assert len(records) == 2
+        assert "test2" in records[1].msg
+        assert "key1=value1" not in records[1].msg
 
 
-def test_logger_filter_records():
-    """
-    message has record if add TestFilter and record have msg "not filter!"
-    """
+def test_highlight(caplog):
+    slogging.configure()
+    log = slogging.getLogger()
 
-    th = setup_logging()
-    log_a = slogging.get_logger("a")
-    log_a.filters = []
-
-    # add exechandler
-    exec_handler = slogging.ExecHandler()
-    log_a.addHandler(exec_handler)
-
-    #add filter
-    f = TestFilter()
-    log_a.addFilter(f)
-
-    called = []
-    def log_cb(event_dict):
-        called.append(event_dict)
-
-    slogging.log_listeners.listeners.append(log_cb)
-    log_a.info("log_a", a=11, b=22)
-    assert not called
-    log_a.info("log_a filtering! ", a=1, b=2)
-    assert called.pop()
+    log.DEV('testmessage')
+    assert "\033[91mtestmessage \033[0m" in caplog.records()[0].msg
 
 
-try:
-    unicode
-    _unicode = True
-except NameError:
-    _unicode = False
-records = []
-def helper_emit_stream_handler(self, record):
-    """
-    Emit a record.
+def test_shortcut_dev_logger(capsys):
+    slogging.DEBUG('testmessage')
+    out, err = capsys.readouterr()
+    assert "\033[91mtestmessage \033[0m" in err
 
-    If a formatter is specified, it is used to format the record.
-    The record is then written to the stream with a trailing newline.  If
-    exception information is present, it is formatted using
-    traceback.print_exception and appended to the stream.  If the stream
-    has an 'encoding' attribute, it is used to determine how to do the
-    output to the stream.
-    """
 
-    records.append(record)
-
-    try:
-        msg = self.format(record)
-        stream = self.stream
-        fs = "%s\n"
-        if not _unicode: #if no unicode support...
-            stream.write(fs % msg)
-        else:
-            try:
-                if (isinstance(msg, unicode) and
-                    getattr(stream, 'encoding', None)):
-                    ufs = u'%s\n'
-                    try:
-                        stream.write(ufs % msg)
-                    except UnicodeEncodeError:
-                        #Printing to terminals sometimes fails. For example,
-                        #with an encoding of 'cp1251', the above write will
-                        #work if written to a stream opened or wrapped by
-                        #the codecs module, but fail when writing to a
-                        #terminal even when the codepage is set to cp1251.
-                        #An extra encoding step seems to be needed.
-                        stream.write((ufs % msg).encode(stream.encoding))
-                else:
-                    stream.write(fs % msg)
-            except UnicodeError:
-                stream.write(fs % msg.encode("UTF-8"))
-        self.flush()
-    except (KeyboardInterrupt, SystemExit):
-        raise
-    except:
-        self.handleError(record)
-
-def standart_logging():
-    """
-    Test stndart loggin
-    2 handlers: basic and stream handler
-    """
-    root_logger = logging.getLogger()
-    root_logger.handlers = [] # clear handlers
-    stream_handler = logging.StreamHandler()
-    logging.StreamHandler.emit = helper_emit_stream_handler # Substitute function for test handlers with formatter
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    stream_handler.setFormatter(formatter)
-    root_logger.addHandler(stream_handler)
-
-    test_handler = TestHandler()
-    root_logger.addHandler(test_handler)
-    root_logger.info("standart logging")
-    record = records.pop()
-    assert 'root' in record.name
-    assert 'INFO' in record.levelname
-    assert 'standart logging' in record.msg
-
-def test_incremental():
-    config_string = ':trace'
-    th = setup_logging(config_string=config_string)
-    log = slogging.get_logger()
-    # incremental context
-    log = log.bind(first='one')
-    log.error('nice', a=1, b=2)
-    assert 'first' in th.logged
-    log = log.bind(second='two')
-    log.error('nice', a=1, b=2)
-    l = th.logged
-    assert 'first' in l and 'two' in l
-    log.error('nice', a=3, b=2)
-    l = th.logged
-    assert 'a=3' in l and 'b=2' in l
-
-def test_count_logging_handlers():
+def test_logging_reconfigure():
     config_string = ':WARNING'
     config_string1 = ':DEBUG,eth:INFO'
     config_string2 = ':DEBUG,eth.vm:INFO'
     main_logger = slogging.getLogger()
-    # check main logger
-    slogging.configure(config_string)
-    assert len(main_logger.handlers) == 1
-    slogging.configure(config_string)
-    assert len(main_logger.handlers) == 1
 
-    # check named logger
+    slogging.configure(config_string)
+    assert len(main_logger.handlers) == 2  # pytest-capturelog adds it's own handler
+    slogging.configure(config_string)
+    assert len(main_logger.handlers) == 2  # pytest-capturelog adds it's own handler
+
     eth_logger = slogging.getLogger('eth')
     slogging.configure(config_string1)
-    assert len(eth_logger.handlers) == 1
+    assert len(eth_logger.handlers) == 0
     slogging.configure(config_string1)
-    assert len(eth_logger.handlers) == 1
+    assert len(eth_logger.handlers) == 0
 
-    # check child of named logger
     eth_vm_logger = slogging.getLogger('eth.vm')
     slogging.configure(config_string2)
-    assert len(eth_vm_logger.handlers) == 1
+    assert len(eth_vm_logger.handlers) == 0
     slogging.configure(config_string2)
-    assert len(eth_vm_logger.handlers) == 1
+    assert len(eth_vm_logger.handlers) == 0
 
-if __name__ == '__main__':
-    pass
+
+def test_set_level():
+    slogging.set_level('test', 'CRITICAL')
+    assert slogging.getLogger('test').level == logging.CRITICAL

--- a/ethereum/tests/test_solidity.py
+++ b/ethereum/tests/test_solidity.py
@@ -630,8 +630,6 @@ contract contract_sub {
 def test_solidity_compile_rich():
     contract_info = get_solidity().compile_rich(compile_rich_contract)
 
-    import json
-    print json.dumps(contract_info)
     assert len(contract_info) == 2
     assert set(contract_info.keys()) == {'contract_add', 'contract_sub'}
     assert set(contract_info['contract_add'].keys()) == {'info', 'code'}

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -391,6 +391,7 @@ int256 = BigEndianInt(256)
 hash32 = Binary.fixed_length(32)
 trie_root = Binary.fixed_length(32, allow_empty=True)
 
+
 class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -402,5 +403,7 @@ class bcolors:
     UNDERLINE = '\033[4m'
 
 
-def DEBUG(*args, **kargs):
-    print(bcolors.FAIL + repr(args) + repr(kargs) + bcolors.ENDC)
+def DEBUG(msg, *args, **kwargs):
+    from ethereum import slogging
+
+    slogging.DEBUG(msg, *args, **kwargs)


### PR DESCRIPTION
Refactor `slogging` to fix several issues

- Improve overall readability
- Enable logging re-configuration without side-effects
- Stop bound loggers "contaminating" their parents
- Add support to highlight log messages to ease debugging during development