### PR TITLE
Error improvements and Geth defaults

### DIFF
--- a/ethereum/blocks.py
+++ b/ethereum/blocks.py
@@ -405,15 +405,15 @@ class Block(rlp.Serializable):
             if self.prevhash != parent.header.hash:
                 raise ValueError("Block's prevhash and parent's hash do not match")
             if self.number != parent.header.number + 1:
-                raise ValueError("Block's number is not the successor of its parent number")
+                raise ValueError("Block's number [%d] is not the successor of its parent number [%d]" % (self.number, parent.header.number))
             if not check_gaslimit(parent, self.gas_limit):
-                raise ValueError("Block's gaslimit is inconsistent with its parent's gaslimit")
+                raise ValueError("Block's gaslimit [%s] is inconsistent with its parent's gaslimit [%d]" % (self.gas_limit, parent.header.gas_limit))
             if self.difficulty != calc_difficulty(parent, self.timestamp):
-                raise ValueError("Block's difficulty is inconsistent with its parent's difficulty")
+                raise ValueError("Block's difficulty [%s] is inconsistent with its expected difficulty [%d]" % ( self.difficulty, calc_difficulty(parent, self.timestamp)))
             if self.gas_used > self.gas_limit:
-                raise ValueError("Gas used exceeds gas limit")
+                raise ValueError("Gas used [%d] exceeds gas limit [%d]" % (self.gas_used, self.gas_limit))
             if self.timestamp <= parent.header.timestamp:
-                raise ValueError("Timestamp equal to or before parent")
+                raise ValueError("Timestamp [%d] equal to or before parent [%d]" % (self.timestamp, parent.header.timestamp))
 
         for uncle in uncles:
             assert isinstance(uncle, BlockHeader)
@@ -559,6 +559,7 @@ class Block(rlp.Serializable):
 
         This is equivalent to ``header.hash``.
         """
+
         return utils.sha3(rlp.encode(self.header))
 
     def hex_hash(self):

--- a/ethereum/blocks.py
+++ b/ethereum/blocks.py
@@ -43,7 +43,7 @@ def calc_difficulty(parent, timestamp):
     # If we enter a special mode where the genesis difficulty starts off below
     # the minimal difficulty, we allow low-difficulty blocks (this will never
     # happen in the official protocol)
-    o = int(max(parent.difficulty + offset * sign, min(parent.difficulty, config['MIN_DIFF'])))
+    o = int(max(parent.difficulty + offset * sign, config['MIN_DIFF']))
     period_count = (parent.number + 1) // config['EXPDIFF_PERIOD']
     if period_count >= config['EXPDIFF_FREE_PERIODS']:
         o = max(o + 2**(period_count - config['EXPDIFF_FREE_PERIODS']), config['MIN_DIFF'])

--- a/ethereum/config.py
+++ b/ethereum/config.py
@@ -40,7 +40,7 @@ default_config = dict(
     MAX_EXTRADATA_LENGTH=32,
     # Exponential difficulty timebomb period
     EXPDIFF_PERIOD=100000,
-    EXPDIFF_FREE_PERIODS=2
+    EXPDIFF_FREE_PERIODS=1
 )
 assert default_config['NEPHEW_REWARD'] == \
     default_config['BLOCK_REWARD'] // 32

--- a/ethereum/config.py
+++ b/ethereum/config.py
@@ -40,7 +40,7 @@ default_config = dict(
     MAX_EXTRADATA_LENGTH=32,
     # Exponential difficulty timebomb period
     EXPDIFF_PERIOD=100000,
-    EXPDIFF_FREE_PERIODS=1
+    EXPDIFF_FREE_PERIODS=2
 )
 assert default_config['NEPHEW_REWARD'] == \
     default_config['BLOCK_REWARD'] // 32


### PR DESCRIPTION
This PR contains some additional info when things go wrong during block header validation, and also uses the same defaults as the Go client for difficulty calculation.  

Example output during errors (printed when there were no errors) : 

```
Block's number [9] is not the successor of its parent number [8]
Block's gaslimit [133302791] is inconsistent with its parent's gaslimit [133172740]
Block's difficulty [131456] is inconsistent with its expected difficulty [131456]
Gas used [0] exceeds gas limit [133302791]
Timestamp [1441481769] equal to or before parent [1441352831]
```
