### PR TITLE
exclusively use pycryptodome for sha3_256 hashing 

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,5 +2,5 @@ tox
 coveralls
 pytest
 pytest-catchlog==1.1
-pytest-timeout
+pytest-timeout==0.5
 https://github.com/ethereum/serpent/tarball/develop

--- a/ethereum/ethash_utils.py
+++ b/ethereum/ethash_utils.py
@@ -1,4 +1,6 @@
-import sha3
+from Crypto.Hash import keccak
+sha3_256 = lambda x: keccak.new(digest_bits=256, data=x)
+sha3_512 = lambda x: keccak.new(digest_bits=512, data=x)
 from rlp.utils import decode_hex, encode_hex
 import sys
 
@@ -59,11 +61,11 @@ def to_bytes(x):
 
 # sha3 hash function, outputs 64 bytes
 def sha3_512(x):
-    return hash_words(lambda v: sha3.sha3_512(to_bytes(v)).digest(), 64, x)
+    return hash_words(sha3_512(to_bytes(v)).digest(), 64, x)
 
 
 def sha3_256(x):
-    return hash_words(lambda v: sha3.sha3_256(to_bytes(v)).digest(), 32, x)
+    return hash_words(sha3_256(to_bytes(v)).digest(), 32, x)
 
 
 def xor(a, b):

--- a/ethereum/keys.py
+++ b/ethereum/keys.py
@@ -23,7 +23,8 @@ your wallet file.
 import binascii
 import struct
 from math import ceil
-from sha3 import sha3_256
+from Crypto.Hash import keccak
+sha3_256 = lambda x: keccak.new(digest_bits=256, data=x)
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
 from Crypto.Util import Counter

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -1,8 +1,5 @@
-try:
-    from keccak import sha3_256  # pypy
-except ImportError:
-    from sha3 import sha3_256 as _sha3_256
-    sha3_256 = lambda x: _sha3_256(x).digest()
+from Crypto.Hash import keccak
+sha3_256 = lambda x: keccak.new(digest_bits=256, data=x).digest()
 from bitcoin import privtopub
 import sys
 import rlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pysha3
 PyYAML
 repoze.lru
 pbkdf2
-pycrypto
+pycryptodome>=3.3.1
 scrypt
 https://github.com/ethereum/pyrlp/tarball/develop
 https://github.com/ethereum/ethash/tarball/master


### PR DESCRIPTION
pycryptodome works for both py27 and pypy and supports keccak
Use pycryptodome for sha3_256 hashing
Use version 3.3.1 or higher of pycryptodome

Force version 0.5 of pytest-timout, since newer versions seem to break coverage thus not allowing travis to run the test suite.