### PR TITLE
API calls should not print results

### DIFF
--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -100,7 +100,7 @@ class ContractTranslator():
     def is_unknown_type(self, name):
         return self.function_data[name]["is_unknown_type"]
 
-    def listen(self, log, noprint=False):
+    def listen(self, log, noprint=True):
         if not len(log.topics) or log.topics[0] not in self.event_data:
             return
         types = self.event_data[log.topics[0]]['types']


### PR DESCRIPTION
I think `noprint` should default to `True` in the `listen` method of the contract translator ABI for the following reasons:
* Why print the return value inside the method and provide an option to turn it off, when a developer can easily use `print(ct.listen(log))` to print the return value to provide the same functionality?
* It doesn't make any sense for API methods to print results as well as return them. API methods should provide an interface for programmers to deal with results, with the programmer deciding how that result is returned to the user, not the API.
* It's not consistent with other API methods. This is the only method where you must pass `noprint=True` to it in order to preventing it to from printing the console.
* It provides a headache for developers creating console applications.

Ideally the `noprint` argument should be removed entirely, but this may cause compatibility issues with Python applications already using this method, until a major version change is made.