### PR TITLE
Fix bug with 0x prefixed addresses

### DIFF
--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -236,7 +236,7 @@ def encode_single(typ, arg):
             return zpad(arg, 32)
         elif len(arg) == 40:
             return zpad(decode_hex(arg), 32)
-        elif len(arg) == 42 and arg[2:] == '0x':
+        elif len(arg) == 42 and arg[:2] == '0x':
             return zpad(decode_hex(arg[2:]), 32)
         else:
             raise EncodingError("Could not parse address: %r" % arg)


### PR DESCRIPTION
### What was wrong

The `encode_single` function had an error in how it handled addresses that are `0x` prefixed.

### How was it fixed?

Changed the string slicing to appropriately grab the first two characters.

#### Cute animal picture

![tumblr_l8dfet35wm1qzgjdbo1_400](https://cloud.githubusercontent.com/assets/824194/13229828/eefaf546-d95f-11e5-9772-937659726992.jpg)
