### PR TITLE
pyethapp's on_new_head_candidate callbacks are not called when head_candidate changed during validation

### DIFF
--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -345,7 +345,7 @@ class Chain(object):
         log.debug('add tx', num_txs=self.num_transactions(), tx=transaction, on=head_candidate)
         if self.head_candidate.includes_transaction(transaction.hash):
             log.debug('known tx')
-            return
+            return False
         old_state_root = head_candidate.state_root
         # revert finalization
         head_candidate.state_root = self.pre_finalize_state_root
@@ -363,8 +363,7 @@ class Chain(object):
         # we might have a new head_candidate (due to ctx switches in pyethapp)
         if self.head_candidate != head_candidate:
             log.debug('head_candidate changed during validation, trying again')
-            self.add_transaction(transaction)
-            return
+            return self.add_transaction(transaction)
 
         self.pre_finalize_state_root = head_candidate.state_root
         head_candidate.finalize()

--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -345,7 +345,7 @@ class Chain(object):
         log.debug('add tx', num_txs=self.num_transactions(), tx=transaction, on=head_candidate)
         if self.head_candidate.includes_transaction(transaction.hash):
             log.debug('known tx')
-            return False
+            return
         old_state_root = head_candidate.state_root
         # revert finalization
         head_candidate.state_root = self.pre_finalize_state_root


### PR DESCRIPTION
Hi,

While I was debugging https://github.com/ethereum/pyethapp/pull/123 I noticed that I'd sometimes 
not get back a True value for `success` https://github.com/ethereum/pyethapp/blob/develop/pyethapp/eth_service.py#L220 when I was running `add_transaction`.  
It looked like things were being added OK in the end so I dug a little deeper and it seemed to be coming from https://github.com/ethereum/pyethereum/blob/develop/ethereum/chain.py#L367  
I was running `pyethapp` and then entered the console mode to use `%debug` to set a few break points and step through code.  I probably sat too long reviewing some parts of the code and things changed so I ended up going down the `head_candidate changed during validation` path more than folks typically would during normal operations.   Since other parts of `add_transaction` return a boolean, I figured it might be good to consistently return a boolean (even on the retry attempts) so the end result propagates back up to the original `add_transaction` caller.    I can't seem to reproduce this behavior except when I'm in the debugger and pausing at certain spots but I suspect it could pop up in a larger network with more moving parts and transactions.

Thank you,

Brian