### PR TITLE
Solidity compile from file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
 python: 2.7
-sudo: false
+sudo: required
+dist: trusty
+before_install:
+  - sudo add-apt-repository -y ppa:ethereum/ethereum
+  - sudo apt-get update
+  - sudo apt-get install -y solc
+
 env:
 - TOX_ENV=py27
 install:


### PR DESCRIPTION
This adds the ability to compile `.sol` files by `path` instead of a `code` string with `solc_wrapper`.

Now it is possible to make full use of the `import` statement of solidity.

Note: libraries still need to be deployed ahead of time and provided through the `libraries={...}` kwarg. But now you can use the same source file for deployment and reference in the `import`.