### PR TITLE
better solidity_names

### DIFF
--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -96,57 +96,19 @@ def compiler_version():
         return match.group(1)
 
 
-def solidity_names(code):  # pylint: disable=too-many-branches
+def remove_comments(string):
+        string = re.sub(re.compile("/\*.*?\*/",re.DOTALL ) ,"" ,string) # remove all occurance streamed comments (/*COMMENT */) from string
+        string = re.sub(re.compile("//.*?\n" ) ,"" ,string) # remove all occurance singleline comments (//COMMENT\n ) from string
+        return string
+
+
+def solidity_names(code):
     """ Return the library and contract names in order of appearence. """
     names = []
-    in_string = None
-    backslash = False
-    comment = None
+    cleancode = remove_comments(code)
 
-    # "parse" the code by hand to handle the corner cases:
-    #  - the contract or library can be inside a comment or string
-    #  - multiline comments
-    #  - the contract and library keywords could not be at the start of the line
-    for pos, char in enumerate(code):
-        if in_string:
-            if not backslash and in_string == char:
-                in_string = None
-                backslash = False
-
-            if char == '\\':  # pylint: disable=simplifiable-if-statement
-                backslash = True
-            else:
-                backslash = False
-
-        elif comment == '//':
-            if char in ('\n', '\r'):
-                comment = None
-
-        elif comment == '/*':
-            if char == '*' and code[pos + 1] == '/':
-                comment = None
-
-        else:
-            if char == '"' or char == "'":
-                in_string = char
-
-            if char == '/':
-                if code[pos + 1] == '/':
-                    comment = '//'
-                if code[pos + 1] == '*':
-                    comment = '/*'
-
-            if char == 'c' and code[pos: pos + 8] == 'contract':
-                result = re.match('^contract[^_$a-zA-Z]+([_$a-zA-Z][_$a-zA-Z0-9]*)', code[pos:])
-
-                if result:
-                    names.append(('contract', result.groups()[0]))
-
-            if char == 'l' and code[pos: pos + 7] == 'library':
-                result = re.match('^library[^_$a-zA-Z]+([_$a-zA-Z][_$a-zA-Z0-9]*)', code[pos:])
-
-                if result:
-                    names.append(('library', result.groups()[0]))
+    for m in re.findall(r'^\s*?(contract|library)\s+?(\S*?)\s+?', cleancode, re.MULTILINE):
+        names.append((m[0], m[1]))
 
     return names
 

--- a/ethereum/tests/test_solidity.py
+++ b/ethereum/tests/test_solidity.py
@@ -12,6 +12,56 @@ SOLIDITY_AVAILABLE = get_solidity() is not None
 CONTRACTS_DIR = path.join(path.dirname(__file__), 'contracts')
 
 
+def test_solidity_names():
+    # test simple extracting names
+    code = '''
+contract test1 {}
+contract test2 {}
+'''
+    assert _solidity.solidity_names(code) == [('contract', 'test1'), ('contract', 'test2')]
+
+    # test with odd comment
+    code = '''
+contract test1
+// odd comment here
+/* more odd comments */
+{}
+'''
+    assert _solidity.solidity_names(code) == [('contract', 'test1')]
+
+    # test with contract in comment
+    code = '''
+contract test1 {}
+//contract test2 {}
+/*contract test3 {}*/
+/*
+contract test4 {}
+*/
+'''
+    assert _solidity.solidity_names(code) == [('contract', 'test1')]
+
+    # test with a var named 'subcontract'
+    code = '''
+contract test1 {
+    _subcontract = new subcontract();
+}
+'''
+    assert _solidity.solidity_names(code) == [('contract', 'test1')]
+
+    # test with a contract named subcontract
+    code = '''
+contract subcontract {}
+'''
+    assert _solidity.solidity_names(code) == [('contract', 'subcontract')]
+
+    # test with a library
+    code = '''
+contract test1 {}
+library test2 {}
+'''
+    assert _solidity.solidity_names(code) == [('contract', 'test1'), ('library', 'test2')]
+
+
 @pytest.mark.skipif(not SOLIDITY_AVAILABLE, reason='solc compiler not available')
 def test_library_from_file():
     state = tester.state()


### PR DESCRIPTION
better solidity_names that doesn't fail when a contract contains a var that has 'contract' in it's name.

basically back to the old regex but first clean the comments from the code.