### PR TITLE
event parsing, tests, real -> fixed

### DIFF
--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -1,4 +1,6 @@
 # -*- coding: utf8 -*-
+from __future__ import print_function
+
 import ast
 import re
 import warnings
@@ -7,8 +9,23 @@ import yaml  # use yaml instead of json to get non unicode (works with ascii onl
 from rlp.utils import decode_hex, encode_hex
 
 from ethereum import utils
-from ethereum.utils import encode_int, zpad, big_endian_to_int, is_numeric, is_string, ceil32
-from ethereum.utils import isnumeric, TT256, TT255
+from ethereum.utils import (
+    big_endian_to_int, ceil32, int_to_big_endian, encode_int, is_numeric, isnumeric, is_string,
+    rzpad, TT255, TT256, zpad,
+)
+
+# The number of bytes is encoded as a uint256
+# Type used to encode a string/bytes length
+INT256 = 'uint', '256', []
+lentyp = INT256  # pylint: disable=invalid-name
+
+
+class EncodingError(Exception):
+    pass
+
+
+class ValueOutOfBounds(EncodingError):
+    pass
 
 
 def json_decode(data):
@@ -26,20 +43,40 @@ def split32(data):
     return all_pieces
 
 
-def _canonical_name(name):
-    """ Replace aliases to the corresponding type. """
-
-    if name.startswith('int['):
-        return 'uint256' + name[3:]
+def _canonical_type(name):  # pylint: disable=too-many-return-statements
+    """ Replace aliases to the corresponding type to compute the ids. """
 
     if name == 'int':
+        return 'int256'
+
+    if name == 'uint':
         return 'uint256'
 
-    if name.startswith('real['):
-        return 'real128x128' + name[4:]
+    if name == 'fixed':
+        return 'fixed128x128'
 
-    if name == 'real':
-        return 'real128x128'
+    if name == 'ufixed':
+        return 'ufixed128x128'
+
+    if name.startswith('int['):
+        return 'int256' + name[3:]
+
+    if name.startswith('uint['):
+        return 'uint256' + name[4:]
+
+    if name.startswith('fixed['):
+        return 'fixed128x128' + name[5:]
+
+    if name.startswith('ufixed['):
+        return 'ufixed128x128' + name[6:]
+
+    return name
+
+
+def normalize_name(name):
+    """ Return normalized event/function name. """
+    if '(' in name:
+        return name[:name.find('(')]
 
     return name
 
@@ -55,7 +92,7 @@ def method_id(name, encode_types):
     big-endian) of the Keccak (SHA-3) hash of the signature of the function.
     """
     function_types = [
-        _canonical_name(type_)
+        _canonical_type(type_)
         for type_ in encode_types
     ]
 
@@ -83,7 +120,7 @@ def event_id(name, encode_types):
     """
 
     event_types = [
-        _canonical_name(type_)
+        _canonical_type(type_)
         for type_ in encode_types
     ]
 
@@ -95,12 +132,261 @@ def event_id(name, encode_types):
     return big_endian_to_int(utils.sha3(event_signature))
 
 
-def _normalize_name(name):
-    """ Return normalized event/function name. """
-    if '(' in name:
-        return name[:name.find('(')]
+def decint(n, signed=False):  # pylint: disable=invalid-name,too-many-branches
+    ''' Decode an unsigned/signed integer. '''
 
-    return name
+    if isinstance(n, str):
+        n = utils.to_string(n)
+
+    if n is True:
+        return 1
+
+    if n is False:
+        return 0
+
+    if n is None:
+        return 0
+
+    if is_numeric(n):
+        if signed:
+            if not -TT255 <= n <= TT255 - 1:
+                raise EncodingError('Number out of range: %r' % n)
+        else:
+            if not 0 <= n <= TT256 - 1:
+                raise EncodingError('Number out of range: %r' % n)
+
+        return n
+
+    if is_string(n):
+        if len(n) > 32:
+            raise EncodingError('String too long: %r' % n)
+
+        if len(n) == 40:
+            int_bigendian = decode_hex(n)
+        else:
+            int_bigendian = n  # pylint: disable=redefined-variable-type
+
+        result = big_endian_to_int(int_bigendian)
+        if signed:
+            if result >= TT255:
+                result -= TT256
+
+            if not -TT255 <= result <= TT255 - 1:
+                raise EncodingError('Number out of range: %r' % n)
+        else:
+            if not 0 <= result <= TT256 - 1:
+                raise EncodingError('Number out of range: %r' % n)
+
+        return result
+
+    raise EncodingError('Cannot decode integer: %r' % n)
+
+
+def encode_single(typ, arg):  # pylint: disable=too-many-return-statements,too-many-branches,too-many-statements,too-many-locals
+    ''' Encode `arg` as `typ`.
+
+    `arg` will be encoded in a best effort manner, were necessary the function
+    will try to correctly define the underlying binary representation (ie.
+    decoding a hex-encoded address/hash).
+
+    Args:
+        typ (Tuple[(str, int, list)]): A 3-tuple defining the `arg` type.
+
+            The first element defines the type name.
+            The second element defines the type length in bits.
+            The third element defines if it's an array type.
+
+            Together the first and second defines the elementary type, the third
+            element must be present but is ignored.
+
+            Valid type names are:
+                - uint
+                - int
+                - bool
+                - ufixed
+                - fixed
+                - string
+                - bytes
+                - hash
+                - address
+
+        arg (object): The object to be encoded, it must be a python object
+            compatible with the `typ`.
+
+    Raises:
+        ValueError: when an invalid `typ` is supplied.
+        ValueOutOfBounds: when `arg` cannot be encoded as `typ` because of the
+            binary contraints.
+
+    Note:
+        This function don't work with array types, for that use the `enc`
+        function.
+    '''
+    base, sub, _ = typ
+
+    if base == 'uint':
+        sub = int(sub)
+
+        if not (0 < sub <= 256 and sub % 8 == 0):
+            raise ValueError('invalid unsigned integer bit length {}'.format(sub))
+
+        try:
+            i = decint(arg, signed=False)
+        except EncodingError:
+            # arg is larger than 2**256
+            raise ValueOutOfBounds(repr(arg))
+
+        if not 0 <= i < 2 ** sub:
+            raise ValueOutOfBounds(repr(arg))
+
+        value_encoded = int_to_big_endian(i)
+        return zpad(value_encoded, 32)
+
+    if base == 'int':
+        sub = int(sub)
+        bits = sub - 1
+
+        if not (0 < sub <= 256 and sub % 8 == 0):
+            raise ValueError('invalid integer bit length {}'.format(sub))
+
+        try:
+            i = decint(arg, signed=True)
+        except EncodingError:
+            # arg is larger than 2**255
+            raise ValueOutOfBounds(repr(arg))
+
+        if not -2 ** bits <= i < 2 ** bits:
+            raise ValueOutOfBounds(repr(arg))
+
+        value = i % 2 ** sub  # convert negative to "equivalent" positive
+        value_encoded = int_to_big_endian(value)
+        return zpad(value_encoded, 32)
+
+    if base == 'bool':
+        if arg is True:
+            value_encoded = int_to_big_endian(1)
+        elif arg is False:
+            value_encoded = int_to_big_endian(0)
+        else:
+            raise ValueError('%r is not bool' % arg)
+
+        return zpad(value_encoded, 32)
+
+    if base == 'ufixed':
+        sub = str(sub)  # pylint: disable=redefined-variable-type
+
+        high_str, low_str = sub.split('x')
+        high = int(high_str)
+        low = int(low_str)
+
+        if not (0 < high + low <= 256 and high % 8 == 0 and low % 8 == 0):
+            raise ValueError('invalid unsigned fixed length {}'.format(sub))
+
+        if not 0 <= arg < 2 ** high:
+            raise ValueOutOfBounds(repr(arg))
+
+        float_point = arg * 2 ** low
+        fixed_point = int(float_point)
+        return zpad(int_to_big_endian(fixed_point), 32)
+
+    if base == 'fixed':
+        sub = str(sub)  # pylint: disable=redefined-variable-type
+
+        high_str, low_str = sub.split('x')
+        high = int(high_str)
+        low = int(low_str)
+        bits = high - 1
+
+        if not (0 < high + low <= 256 and high % 8 == 0 and low % 8 == 0):
+            raise ValueError('invalid unsigned fixed length {}'.format(sub))
+
+        if not -2 ** bits <= arg < 2 ** bits:
+            raise ValueOutOfBounds(repr(arg))
+
+        float_point = arg * 2 ** low
+        fixed_point = int(float_point)
+        value = fixed_point % 2 ** 256
+        return zpad(int_to_big_endian(value), 32)
+
+    if base == 'string':
+        if isinstance(arg, unicode):
+            arg = arg.encode('utf8')
+        else:
+            try:
+                arg.decode('utf8')
+            except UnicodeDecodeError:
+                raise ValueError('string must be utf8 encoded')
+
+        if len(sub):  # fixed length
+            if not 0 <= len(arg) <= int(sub):
+                raise ValueError('invalid string length {}'.format(sub))
+
+            if not 0 <= int(sub) <= 32:
+                raise ValueError('invalid string length {}'.format(sub))
+
+            return rzpad(arg, 32)
+
+        if not 0 <= len(arg) < TT256:
+            raise Exception('Integer invalid or out of range: %r' % arg)
+
+        length_encoded = zpad(int_to_big_endian(len(arg)), 32)
+        value_encoded = rzpad(arg, utils.ceil32(len(arg)))
+
+        return length_encoded + value_encoded
+
+    if base == 'bytes':
+        if not is_string(arg):
+            raise EncodingError('Expecting string: %r' % arg)
+
+        if len(sub):  # fixed length
+            if not 0 <= len(arg) <= int(sub):
+                raise ValueError('string must be utf8 encoded')
+
+            if not 0 <= int(sub) <= 32:
+                raise ValueError('string must be utf8 encoded')
+
+            return rzpad(arg, 32)
+
+        if not 0 <= len(arg) < TT256:
+            raise Exception('Integer invalid or out of range: %r' % arg)
+
+        length_encoded = zpad(int_to_big_endian(len(arg)), 32)
+        value_encoded = rzpad(arg, utils.ceil32(len(arg)))
+
+        return length_encoded + value_encoded
+
+    if base == 'hash':
+        if not (int(sub) and int(sub) <= 32):
+            raise EncodingError('too long: %r' % arg)
+
+        if isnumeric(arg):
+            return zpad(encode_int(arg), 32)
+
+        if len(arg) == int(sub):
+            return zpad(arg, 32)
+
+        if len(arg) == int(sub) * 2:
+            return zpad(decode_hex(arg), 32)
+
+        raise EncodingError('Could not parse hash: %r' % arg)
+
+    if base == 'address':
+        assert sub == ''
+
+        if isnumeric(arg):
+            return zpad(encode_int(arg), 32)
+
+        if len(arg) == 20:
+            return zpad(arg, 32)
+
+        if len(arg) == 40:
+            return zpad(decode_hex(arg), 32)
+
+        if len(arg) == 42 and arg[:2] == '0x':
+            return zpad(decode_hex(arg[2:]), 32)
+
+        raise EncodingError('Could not parse address: %r' % arg)
+    raise EncodingError('Unhandled type: %r %r' % (base, sub))
 
 
 class ContractTranslator(object):
@@ -126,7 +412,7 @@ class ContractTranslator(object):
 
             # type can be omitted, defaulting to function
             if description.get('type', 'function') == 'function':
-                normalized_name = _normalize_name(description['name'])
+                normalized_name = normalize_name(description['name'])
 
                 decode_types = [
                     element['type']
@@ -142,7 +428,7 @@ class ContractTranslator(object):
                 }
 
             elif description['type'] == 'event':
-                normalized_name = _normalize_name(description['name'])
+                normalized_name = normalize_name(description['name'])
 
                 indexed = [
                     element['indexed']
@@ -152,6 +438,7 @@ class ContractTranslator(object):
                     element['name']
                     for element in description['inputs']
                 ]
+                # event_id == topics[0]
                 self.event_data[event_id(normalized_name, encode_types)] = {
                     'types': encode_types,
                     'name': normalized_name,
@@ -171,6 +458,14 @@ class ContractTranslator(object):
 
             else:
                 raise ValueError('Unknown type {}'.format(description['type']))
+
+    def encode(self, function_name, args):
+        warnings.warn('encode is deprecated, please use encode_function_call', DeprecationWarning)
+        return self.encode_function_call(function_name, args)
+
+    def decode(self, function_name, data):
+        warnings.warn('decode is deprecated, please use decode_function_result', DeprecationWarning)
+        return self.decode_function_result(function_name, data)
 
     def encode_function_call(self, function_name, args):
         """ Return the encoded function call.
@@ -196,9 +491,20 @@ class ContractTranslator(object):
 
         return function_selector + arguments
 
-    def encode(self, function_name, args):
-        warnings.warn('encode is deprecated, please use encode_function_call', DeprecationWarning)
-        return self.encode_function_call(function_name, args)
+    def decode_function_result(self, function_name, data):
+        """ Return the function call result decoded.
+
+        Args:
+            function_name (str): One of the existing functions described in the
+                contract interface.
+            data (bin): The encoded result from calling `function_name`.
+
+        Return:
+            List[object]: The values returned by the call to `function_name`.
+        """
+        description = self.function_data[function_name]
+        arguments = decode_abi(description['decode_types'], data)
+        return arguments
 
     def encode_constructor_arguments(self, args):
         """ Return the encoded constructor call. """
@@ -207,149 +513,79 @@ class ContractTranslator(object):
 
         return encode_abi(self.constructor_data['encode_types'], args)
 
-    def decode(self, function_name, data):
-        description = self.function_data[function_name]
-        return decode_abi(description['decode_types'], data)
+    def decode_event(self, log_topics, log_data):
+        """ Return a dictionary representation the log.
+
+        Note:
+            This function won't work with anonymous events.
+
+        Args:
+            log_topics (List[bin]): The log's indexed arguments.
+            log_data (bin): The encoded non-indexed arguments.
+        """
+        # https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#function-selector-and-argument-encoding
+
+        # topics[0]: keccak(EVENT_NAME+"("+EVENT_ARGS.map(canonical_type_of).join(",")+")")
+        # If the event is declared as anonymous the topics[0] is not generated;
+        if not len(log_topics) or log_topics[0] not in self.event_data:
+            raise ValueError('Unknow log type')
+
+        event_id_ = log_topics[0]
+
+        event = self.event_data[event_id_]
+
+        # data: abi_serialise(EVENT_NON_INDEXED_ARGS)
+        # EVENT_NON_INDEXED_ARGS is the series of EVENT_ARGS that are not
+        # indexed, abi_serialise is the ABI serialisation function used for
+        # returning a series of typed values from a function.
+        unindexed_types = [
+            type_
+            for type_, indexed in zip(event['types'], event['indexed'])
+            if not indexed
+        ]
+        unindexed_args = decode_abi(unindexed_types, log_data)
+
+        # topics[n]: EVENT_INDEXED_ARGS[n - 1]
+        # EVENT_INDEXED_ARGS is the series of EVENT_ARGS that are indexed
+        indexed_count = 1  # skip topics[0]
+
+        result = {}
+        for name, type_, indexed in zip(event['names'], event['types'], event['indexed']):
+            if indexed:
+                topic_bytes = utils.zpad(
+                    utils.encode_int(log_topics[indexed_count]),
+                    32,
+                )
+                indexed_count += 1
+                value = decode_single(process_type(type_), topic_bytes)
+            else:
+                value = unindexed_args.pop(0)
+
+            result[name] = value
+        result['_event_type'] = utils.to_string(event['name'])
+
+        return result
 
     def listen(self, log, noprint=True):
-        if not len(log.topics) or log.topics[0] not in self.event_data:
-            return
-        types = self.event_data[log.topics[0]]['types']
-        name = self.event_data[log.topics[0]]['name']
-        names = self.event_data[log.topics[0]]['names']
-        indexed = self.event_data[log.topics[0]]['indexed']
-        indexed_types = [types[i] for i in range(len(types))
-                         if indexed[i]]
-        unindexed_types = [types[i] for i in range(len(types))
-                           if not indexed[i]]
-        # print('listen', encode_hex(log.data), log.topics)
-        deserialized_args = decode_abi(unindexed_types, log.data)
-        o = {}
-        c1, c2 = 0, 0
-        for i in range(len(names)):
-            if indexed[i]:
-                topic_bytes = utils.zpad(utils.encode_int(log.topics[c1 + 1]), 32)
-                o[names[i]] = decode_single(process_type(indexed_types[c1]),
-                                            topic_bytes)
-                c1 += 1
-            else:
-                o[names[i]] = deserialized_args[c2]
-                c2 += 1
-        o["_event_type"] = utils.to_string(name)
+        """
+        Return a dictionary representation of the Log instance.
+
+        Note:
+            This function won't work with anonymous events.
+
+        Args:
+            log (processblock.Log): The Log instance that needs to be parsed.
+            noprint (bool): Flag to turn off priting of the decoded log instance.
+        """
+        try:
+            result = self.decode_event(log.topics, log.data)
+        except ValueError:
+            return  # api compatibility
+
         if not noprint:
-            print(o)
-        return o
+            print(result)
 
-
-class EncodingError(Exception):
-    pass
-
-
-class ValueOutOfBounds(EncodingError):
-    pass
-
-
-# Decode an unsigned/signed integer
-def decint(n, signed=False):
-    if isinstance(n, str):
-        n = utils.to_string(n)
-
-    if is_numeric(n):
-        min_, max_ = (-TT255, TT255 - 1) if signed else (0, TT256 - 1)
-        if n > max_ or n < min_:
-            raise EncodingError("Number out of range: %r" % n)
-        return n
-    elif is_string(n):
-        if len(n) == 40:
-            n = decode_hex(n)
-        if len(n) > 32:
-            raise EncodingError("String too long: %r" % n)
-
-        i = big_endian_to_int(n)
-        return (i - TT256) if signed and i >= TT255 else i
-    elif n is True:
-        return 1
-    elif n is False or n is None:
-        return 0
-    else:
-        raise EncodingError("Cannot encode integer: %r" % n)
-
-
-# Encodes a base datum
-def encode_single(typ, arg):
-    base, sub, _ = typ
-    # Unsigned integers: uint<sz>
-    if base == 'uint':
-        sub = int(sub)
-        i = decint(arg, False)
-
-        if not 0 <= i < 2 ** sub:
-            raise ValueOutOfBounds(repr(arg))
-        return zpad(encode_int(i), 32)
-    # bool: int<sz>
-    elif base == 'bool':
-        assert isinstance(arg, bool)
-        return zpad(encode_int(int(arg)), 32)
-    # Signed integers: int<sz>
-    elif base == 'int':
-        sub = int(sub)
-        i = decint(arg, True)
-        if not -2 ** (sub - 1) <= i < 2 ** (sub - 1):
-            raise ValueOutOfBounds(repr(arg))
-        return zpad(encode_int(i % 2 ** sub), 32)
-    # Unsigned reals: ureal<high>x<low>
-    elif base == 'ureal':
-        high, low = [int(x) for x in sub.split('x')]
-        if not 0 <= arg < 2 ** high:
-            raise ValueOutOfBounds(repr(arg))
-        return zpad(encode_int(int(arg * 2 ** low)), 32)
-    # Signed reals: real<high>x<low>
-    elif base == 'real':
-        high, low = [int(x) for x in sub.split('x')]
-        if not -2 ** (high - 1) <= arg < 2 ** (high - 1):
-            raise ValueOutOfBounds(repr(arg))
-        i = int(arg * 2 ** low)
-        return zpad(encode_int(i % 2 ** (high + low)), 32)
-    # Strings
-    elif base == 'string' or base == 'bytes':
-        if not is_string(arg):
-            raise EncodingError("Expecting string: %r" % arg)
-        # Fixed length: string<sz>
-        if len(sub):
-            assert int(sub) <= 32
-            assert len(arg) <= int(sub)
-            return arg + b'\x00' * (32 - len(arg))
-        # Variable length: string
-        else:
-            return zpad(encode_int(len(arg)), 32) + \
-                arg + \
-                b'\x00' * (utils.ceil32(len(arg)) - len(arg))
-    # Hashes: hash<sz>
-    elif base == 'hash':
-        if not (int(sub) and int(sub) <= 32):
-            raise EncodingError("too long: %r" % arg)
-        if isnumeric(arg):
-            return zpad(encode_int(arg), 32)
-        elif len(arg) == int(sub):
-            return zpad(arg, 32)
-        elif len(arg) == int(sub) * 2:
-            return zpad(decode_hex(arg), 32)
-        else:
-            raise EncodingError("Could not parse hash: %r" % arg)
-    # Addresses: address (== hash160)
-    elif base == 'address':
-        assert sub == ''
-        if isnumeric(arg):
-            return zpad(encode_int(arg), 32)
-        elif len(arg) == 20:
-            return zpad(arg, 32)
-        elif len(arg) == 40:
-            return zpad(decode_hex(arg), 32)
-        elif len(arg) == 42 and arg[:2] in {'0x', b'0x'}:
-            return zpad(decode_hex(arg[2:]), 32)
-        else:
-            raise EncodingError("Could not parse address: %r" % arg)
-    raise EncodingError("Unhandled type: %r %r" % (base, sub))
+        return result
 
 
 def process_type(typ):
@@ -374,8 +610,8 @@ def process_type(typ):
             "Integer size out of bounds"
         assert int(sub) % 8 == 0, \
             "Integer size must be multiple of 8"
-    # Check validity of real type
-    elif base == 'ureal' or base == 'real':
+    # Check validity of fixed type
+    elif base == 'ufixed' or base == 'fixed':
         assert re.match('^[0-9]+x[0-9]+$', sub), \
             "Real type must have suffix of form <high>x<low>, eg. 128x128"
         high, low = [int(x) for x in sub.split('x')]
@@ -408,37 +644,31 @@ def get_size(typ):
     return arrlist[-1][0] * o
 
 
-lentyp = 'uint', 256, []
-
-
 # Encodes a single value (static or dynamic)
 def enc(typ, arg):
     base, sub, arrlist = typ
-    sz = get_size(typ)
-    # Encode dynamic-sized strings as <len(str)> + <str>
+    type_size = get_size(typ)
+
     if base in ('string', 'bytes') and not sub:
-        assert isinstance(arg, (str, bytes, utils.unicode)), \
-            "Expecting a string"
-        return enc(lentyp, len(arg)) + \
-            utils.to_string(arg) + \
-            b'\x00' * (utils.ceil32(len(arg)) - len(arg))
+        return encode_single(typ, arg)
+
     # Encode dynamic-sized lists via the head/tail mechanism described in
     # https://github.com/ethereum/wiki/wiki/Proposal-for-new-ABI-value-encoding
-    elif sz is None:
+    if type_size is None:
         assert isinstance(arg, list), \
             "Expecting a list argument"
         subtyp = base, sub, arrlist[:-1]
         subsize = get_size(subtyp)
         myhead, mytail = b'', b''
         if arrlist[-1] == []:
-            myhead += enc(lentyp, len(arg))
+            myhead += enc(INT256, len(arg))
         else:
             assert len(arg) == arrlist[-1][0], \
                 "Wrong array size: found %d, expecting %d" % \
                 (len(arg), arrlist[-1][0])
         for i in range(len(arg)):
             if subsize is None:
-                myhead += enc(lentyp, 32 * len(arg) + len(mytail))
+                myhead += enc(INT256, 32 * len(arg) + len(mytail))
                 mytail += enc(subtyp, arg[i])
             else:
                 myhead += enc(subtyp, arg[i])
@@ -468,7 +698,7 @@ def encode_abi(types, args):
     myhead, mytail = b'', b''
     for i, arg in enumerate(args):
         if sizes[i] is None:
-            myhead += enc(lentyp, headsize + len(mytail))
+            myhead += enc(INT256, headsize + len(mytail))
             mytail += enc(proctypes[i], args[i])
         else:
             myhead += enc(proctypes[i], args[i])
@@ -493,10 +723,10 @@ def decode_single(typ, data):
     elif base == 'int':
         o = big_endian_to_int(data)
         return (o - 2 ** int(sub)) if o >= 2 ** (int(sub) - 1) else o
-    elif base == 'ureal':
+    elif base == 'ufixed':
         high, low = [int(x) for x in sub.split('x')]
         return big_endian_to_int(data) * 1.0 // 2 ** low
-    elif base == 'real':
+    elif base == 'fixed':
         high, low = [int(x) for x in sub.split('x')]
         o = big_endian_to_int(data)
         i = (o - 2 ** (high + low)) if o >= 2 ** (high + low - 1) else o

--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -309,7 +309,7 @@ def encode_single(typ, arg):  # pylint: disable=too-many-return-statements,too-m
         return zpad(int_to_big_endian(value), 32)
 
     if base == 'string':
-        if isinstance(arg, unicode):
+        if isinstance(arg, utils.unicode):
             arg = arg.encode('utf8')
         else:
             try:

--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -338,6 +338,8 @@ def encode_single(typ, arg):  # pylint: disable=too-many-return-statements,too-m
         if not is_string(arg):
             raise EncodingError('Expecting string: %r' % arg)
 
+        arg = utils.to_string(arg)  # py2: force unicode into str
+
         if len(sub):  # fixed length
             if not 0 <= len(arg) <= int(sub):
                 raise ValueError('string must be utf8 encoded')

--- a/ethereum/tester.py
+++ b/ethereum/tester.py
@@ -44,7 +44,7 @@ k0, k1, k2, k3, k4, k5, k6, k7, k8, k9 = keys[:10]
 a0, a1, a2, a3, a4, a5, a6, a7, a8, a9 = accounts[:10]
 
 try:
-    import serpent
+    import serpent  # pylint: disable=wrong-import-position
     languages['serpent'] = serpent
 except ImportError:
     pass

--- a/ethereum/tests/test_abi.py
+++ b/ethereum/tests/test_abi.py
@@ -2,7 +2,7 @@
 import pytest
 
 from ethereum.utils import (
-    big_endian_to_int, int_to_big_endian, rzpad, sha3, zpad,
+    big_endian_to_int, int_to_big_endian, decode_hex, encode_hex, rzpad, sha3, zpad,
 )
 from ethereum.abi import (
     _canonical_type, decode_abi, decode_single, decint, encode_abi,
@@ -37,10 +37,10 @@ def test_canonical_types():
 
 def test_function_selector():
     # https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#function-selector-and-argument-encoding
-    baz_selector = big_endian_to_int('CDCD77C0'.decode('hex'))
-    bar_selector = big_endian_to_int('AB55044D'.decode('hex'))
-    sam_selector = big_endian_to_int('A5643BF2'.decode('hex'))
-    f_selector = big_endian_to_int('8BE65246'.decode('hex'))
+    baz_selector = big_endian_to_int(decode_hex('CDCD77C0'))
+    bar_selector = big_endian_to_int(decode_hex('AB55044D'))
+    sam_selector = big_endian_to_int(decode_hex('A5643BF2'))
+    f_selector = big_endian_to_int(decode_hex('8BE65246'))
 
     assert big_endian_to_int(sha3('baz(uint32,bool)')[:4]) == baz_selector
     assert big_endian_to_int(sha3('bar(fixed128x128[2])')[:4]) == bar_selector
@@ -79,7 +79,7 @@ def test_event():
 
     result = contract_abi.decode_event(topics, data)
 
-    assert result['_event_type'] == 'Test'
+    assert result['_event_type'] == b'Test'
     assert result['a'] == 1
     assert result['b'] == 2
 
@@ -126,32 +126,32 @@ def test_encode_int():
     int256 = ('int', '256', [])
 
     int256_maximum = (
-        '\x7f\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\x7f\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
     )
     int256_minimum = (
-        '\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-        '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        b'\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
     )
     int256_128 = (
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x80'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x80'
     )
     int256_2_to_31 = (
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x80\x00\x00\x00'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x80\x00\x00\x00'
     )
     int256_negative_one = (
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
     )
 
     assert encode_single(int256, int256_minimum) == int256_minimum
 
-    assert encode_single(int8, 0) == zpad('\x00', 32)
-    assert encode_single(int8, 2 ** 7 - 1) == zpad('\x7f', 32)
-    assert encode_single(int8, -1) == zpad('\xff', 32)
-    assert encode_single(int8, -2 ** 7) == zpad('\x80', 32)
+    assert encode_single(int8, 0) == zpad(b'\x00', 32)
+    assert encode_single(int8, 2 ** 7 - 1) == zpad(b'\x7f', 32)
+    assert encode_single(int8, -1) == zpad(b'\xff', 32)
+    assert encode_single(int8, -2 ** 7) == zpad(b'\x80', 32)
 
     with pytest.raises(ValueOutOfBounds):
         encode_single(int8, 128)
@@ -159,12 +159,12 @@ def test_encode_int():
     with pytest.raises(ValueOutOfBounds):
         encode_single(int8, -129)
 
-    assert encode_single(int32, 0) == zpad('\x00', 32)
-    assert encode_single(int32, 2 ** 7 - 1) == zpad('\x7f', 32)
-    assert encode_single(int32, 2 ** 31 - 1) == zpad('\x7f\xff\xff\xff', 32)
-    assert encode_single(int32, -1) == zpad('\xff\xff\xff\xff', 32)
-    assert encode_single(int32, -2 ** 7) == zpad('\xff\xff\xff\x80', 32)
-    assert encode_single(int32, -2 ** 31) == zpad('\x80\x00\x00\x00', 32)
+    assert encode_single(int32, 0) == zpad(b'\x00', 32)
+    assert encode_single(int32, 2 ** 7 - 1) == zpad(b'\x7f', 32)
+    assert encode_single(int32, 2 ** 31 - 1) == zpad(b'\x7f\xff\xff\xff', 32)
+    assert encode_single(int32, -1) == zpad(b'\xff\xff\xff\xff', 32)
+    assert encode_single(int32, -2 ** 7) == zpad(b'\xff\xff\xff\x80', 32)
+    assert encode_single(int32, -2 ** 31) == zpad(b'\x80\x00\x00\x00', 32)
 
     with pytest.raises(ValueOutOfBounds):
         encode_single(int32, 2 ** 32)
@@ -172,9 +172,9 @@ def test_encode_int():
     with pytest.raises(ValueOutOfBounds):
         encode_single(int32, -(2 ** 32))
 
-    assert encode_single(int256, 0) == zpad('\x00', 32)
-    assert encode_single(int256, 2 ** 7 - 1) == zpad('\x7f', 32)
-    assert encode_single(int256, 2 ** 31 - 1) == zpad('\x7f\xff\xff\xff', 32)
+    assert encode_single(int256, 0) == zpad(b'\x00', 32)
+    assert encode_single(int256, 2 ** 7 - 1) == zpad(b'\x7f', 32)
+    assert encode_single(int256, 2 ** 31 - 1) == zpad(b'\x7f\xff\xff\xff', 32)
     assert encode_single(int256, 2 ** 255 - 1) == int256_maximum
     assert encode_single(int256, -1) == int256_negative_one
     assert encode_single(int256, -2 ** 7) == int256_128
@@ -202,24 +202,24 @@ def test_encode_uint():
     with pytest.raises(ValueOutOfBounds):
         encode_single(uint256, -1)
 
-    assert encode_single(uint8, 0) == zpad('\x00', 32)
-    assert encode_single(uint32, 0) == zpad('\x00', 32)
-    assert encode_single(uint256, 0) == zpad('\x00', 32)
+    assert encode_single(uint8, 0) == zpad(b'\x00', 32)
+    assert encode_single(uint32, 0) == zpad(b'\x00', 32)
+    assert encode_single(uint256, 0) == zpad(b'\x00', 32)
 
-    assert encode_single(uint8, 1) == zpad('\x01', 32)
-    assert encode_single(uint32, 1) == zpad('\x01', 32)
-    assert encode_single(uint256, 1) == zpad('\x01', 32)
+    assert encode_single(uint8, 1) == zpad(b'\x01', 32)
+    assert encode_single(uint32, 1) == zpad(b'\x01', 32)
+    assert encode_single(uint256, 1) == zpad(b'\x01', 32)
 
-    assert encode_single(uint8, 2 ** 8 - 1) == zpad('\xff', 32)
-    assert encode_single(uint32, 2 ** 8 - 1) == zpad('\xff', 32)
-    assert encode_single(uint256, 2 ** 8 - 1) == zpad('\xff', 32)
+    assert encode_single(uint8, 2 ** 8 - 1) == zpad(b'\xff', 32)
+    assert encode_single(uint32, 2 ** 8 - 1) == zpad(b'\xff', 32)
+    assert encode_single(uint256, 2 ** 8 - 1) == zpad(b'\xff', 32)
 
-    assert encode_single(uint32, 2 ** 32 - 1) == zpad('\xff\xff\xff\xff', 32)
-    assert encode_single(uint256, 2 ** 32 - 1) == zpad('\xff\xff\xff\xff', 32)
+    assert encode_single(uint32, 2 ** 32 - 1) == zpad(b'\xff\xff\xff\xff', 32)
+    assert encode_single(uint256, 2 ** 32 - 1) == zpad(b'\xff\xff\xff\xff', 32)
 
     uint256_maximum = (
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
-        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
     )
     assert encode_single(uint256, 2 ** 256 - 1) == uint256_maximum
 
@@ -228,8 +228,8 @@ def test_encode_bool():
     bool_ = ('bool', '', [])
     uint8 = ('uint', '8', [])
 
-    assert encode_single(bool_, True) == zpad('\x01', 32)
-    assert encode_single(bool_, False) == zpad('\x00', 32)
+    assert encode_single(bool_, True) == zpad(b'\x01', 32)
+    assert encode_single(bool_, False) == zpad(b'\x00', 32)
 
     assert encode_single(bool_, True) == encode_single(uint8, 1)
     assert encode_single(bool_, False) == encode_single(uint8, 0)
@@ -238,21 +238,21 @@ def test_encode_bool():
 def test_encode_fixed():
     fixed128x128 = ('fixed', '128x128', [])
 
-    _2_125 = (
-        '00000000000000000000000000000002'
-        '20000000000000000000000000000000'
-    ).decode('hex')
+    _2_125 = decode_hex(
+        b'00000000000000000000000000000002'
+        b'20000000000000000000000000000000'
+    )
 
-    _8_5 = (
-        '00000000000000000000000000000008'
-        '80000000000000000000000000000000'
-    ).decode('hex')
+    _8_5 = decode_hex(
+        b'00000000000000000000000000000008'
+        b'80000000000000000000000000000000'
+    )
 
     assert encode_single(fixed128x128, 2.125) == _2_125
     assert encode_single(fixed128x128, 8.5) == _8_5
 
-    assert encode_single(fixed128x128, 1.125) == (b'\x00'*15 + b'\x01\x20' + b'\x00'*15)
-    assert encode_single(fixed128x128, -1.125) == (b'\xff'*15 + b'\xfe' + b'\xe0' + b'\x00'*15)
+    assert encode_single(fixed128x128, 1.125) == (b'\x00' * 15 + b'\x01\x20' + b'\x00' * 15)
+    assert encode_single(fixed128x128, -1.125) == (b'\xff' * 15 + b'\xfe' + b'\xe0' + b'\x00' * 15)
 
     with pytest.raises(ValueOutOfBounds):
         encode_single(fixed128x128, 2 ** 127)
@@ -264,22 +264,22 @@ def test_encode_fixed():
 def test_encoded_ufixed():
     ufixed128x128 = ('ufixed', '128x128', [])
 
-    _2_125 = (
-        '00000000000000000000000000000002'
-        '20000000000000000000000000000000'
-    ).decode('hex')
+    _2_125 = decode_hex(
+        b'00000000000000000000000000000002'
+        b'20000000000000000000000000000000'
+    )
 
-    _8_5 = (
-        '00000000000000000000000000000008'
-        '80000000000000000000000000000000'
-    ).decode('hex')
+    _8_5 = decode_hex(
+        b'00000000000000000000000000000008'
+        b'80000000000000000000000000000000'
+    )
 
     assert encode_single(ufixed128x128, 2.125) == _2_125
     assert encode_single(ufixed128x128, 8.5) == _8_5
 
-    assert encode_single(ufixed128x128, 0) == (b'\x00'*32)
-    assert encode_single(ufixed128x128, 1.125) == (b'\x00'*15 + b'\x01\x20' + '\x00'*15)
-    assert encode_single(ufixed128x128, 2**127-1) == (b'\x7f' + b'\xff'*15 + b'\x00'*16)
+    assert encode_single(ufixed128x128, 0) == (b'\x00' * 32)
+    assert encode_single(ufixed128x128, 1.125) == (b'\x00' * 15 + b'\x01\x20' + b'\x00' * 15)
+    assert encode_single(ufixed128x128, 2**127 - 1) == (b'\x7f' + b'\xff' * 15 + b'\x00' * 16)
 
     with pytest.raises(ValueOutOfBounds):
         encode_single(ufixed128x128, 2 ** 128 + 1)
@@ -293,18 +293,18 @@ def test_encode_dynamic_bytes():
     uint256 = ('uint', '256', [])
 
     # only the size of the bytes
-    assert encode_single(dynamic_bytes, '') == zpad('\x00', 32)
+    assert encode_single(dynamic_bytes, b'') == zpad(b'\x00', 32)
 
-    a = encode_single(uint256, 1) + rzpad('\x61', 32)
-    assert encode_single(dynamic_bytes, '\x61') == a
+    a = encode_single(uint256, 1) + rzpad(b'\x61', 32)
+    assert encode_single(dynamic_bytes, b'\x61') == a
 
-    dave_bin = (
-        '0000000000000000000000000000000000000000000000000000000000000004'
-        '6461766500000000000000000000000000000000000000000000000000000000'
-    ).decode('hex')
-    dave = encode_single(uint256, 4) + rzpad('\x64\x61\x76\x65', 32)
-    assert encode_single(dynamic_bytes, '\x64\x61\x76\x65') == dave_bin
-    assert encode_single(dynamic_bytes, '\x64\x61\x76\x65') == dave
+    dave_bin = decode_hex(
+        b'0000000000000000000000000000000000000000000000000000000000000004'
+        b'6461766500000000000000000000000000000000000000000000000000000000'
+    )
+    dave = encode_single(uint256, 4) + rzpad(b'\x64\x61\x76\x65', 32)
+    assert encode_single(dynamic_bytes, b'\x64\x61\x76\x65') == dave_bin
+    assert encode_single(dynamic_bytes, b'\x64\x61\x76\x65') == dave
 
 
 def test_encode_dynamic_string():
@@ -325,7 +325,7 @@ def test_encode_hash():
     hash8 = ('hash', '8', [])
 
     assert encode_single(hash8, b'\x00' * 8) == b'\x00' * 32
-    assert encode_single(hash8, '00'*8) == b'\x00'*32
+    assert encode_single(hash8, b'00' * 8) == b'\x00' * 32
 
 
 def test_encode_address():
@@ -378,8 +378,8 @@ def test_encode_decode_fixed():
     fixed_data = encode_single(fixed128x128, 1)
     assert decode_single(fixed128x128, fixed_data) == 1
 
-    fixed_data = encode_single(fixed128x128, 2**127-1)
-    assert decode_single(fixed128x128, fixed_data) == (2**127-1)*1.0
+    fixed_data = encode_single(fixed128x128, 2**127 - 1)
+    assert decode_single(fixed128x128, fixed_data) == (2**127 - 1) * 1.0
 
     fixed_data = encode_single(fixed128x128, -1)
     assert decode_single(fixed128x128, fixed_data) == -1
@@ -414,12 +414,12 @@ def test_encode_decode_address():
         address3,
     ]
     all_addresses_encoded = [
-        address1.encode('hex'),
-        address2.encode('hex'),
-        address3.encode('hex'),
+        encode_hex(address1),
+        encode_hex(address2),
+        encode_hex(address3),
     ]
 
-    assert decode_abi(['address'], encode_abi(['address'], [address1]))[0] == address1.encode('hex')
+    assert decode_abi(['address'], encode_abi(['address'], [address1]))[0] == encode_hex(address1)
 
     addresses_encoded_together = encode_abi(['address[]'], [all_addresses])
     assert decode_abi(['address[]'], addresses_encoded_together)[0] == all_addresses_encoded

--- a/ethereum/tests/test_abi.py
+++ b/ethereum/tests/test_abi.py
@@ -1,80 +1,436 @@
-import os
+# -*- coding: utf8 -*-
 import pytest
+
+from ethereum.utils import (
+    big_endian_to_int, int_to_big_endian, rzpad, sha3, zpad,
+)
+from ethereum.abi import (
+    _canonical_type, decode_abi, decode_single, decint, encode_abi,
+    encode_single, event_id, normalize_name, method_id, ContractTranslator,
+    EncodingError, ValueOutOfBounds,
+)
 import ethereum.testutils as testutils
-from ethereum.slogging import get_logger
-import ethereum.abi as abi
-from ethereum.utils import zpad
 
-logger = get_logger()
+# pylint: disable=invalid-name
 
 
-def test_abi_encode_var_sized_array():
-    abi.encode_abi(['address[]'], [[b'\x00' * 20] * 3])
+def test_canonical_types():
+    # https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#types
+    assert _canonical_type('bool') == 'bool'
+    assert _canonical_type('address') == 'address'
+
+    assert _canonical_type('int') == 'int256'
+    assert _canonical_type('uint') == 'uint256'
+    assert _canonical_type('fixed') == 'fixed128x128'
+    assert _canonical_type('ufixed') == 'ufixed128x128'
+
+    assert _canonical_type('int[]') == 'int256[]'
+    assert _canonical_type('uint[]') == 'uint256[]'
+    assert _canonical_type('fixed[]') == 'fixed128x128[]'
+    assert _canonical_type('ufixed[]') == 'ufixed128x128[]'
+
+    assert _canonical_type('int[100]') == 'int256[100]'
+    assert _canonical_type('uint[100]') == 'uint256[100]'
+    assert _canonical_type('fixed[100]') == 'fixed128x128[100]'
+    assert _canonical_type('ufixed[100]') == 'ufixed128x128[100]'
 
 
-def test_abi_encode_fixed_size_array():
-    abi.encode_abi(['uint16[2]'], [[5, 6]])
+def test_function_selector():
+    # https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#function-selector-and-argument-encoding
+    baz_selector = big_endian_to_int('CDCD77C0'.decode('hex'))
+    bar_selector = big_endian_to_int('AB55044D'.decode('hex'))
+    sam_selector = big_endian_to_int('A5643BF2'.decode('hex'))
+    f_selector = big_endian_to_int('8BE65246'.decode('hex'))
+
+    assert big_endian_to_int(sha3('baz(uint32,bool)')[:4]) == baz_selector
+    assert big_endian_to_int(sha3('bar(fixed128x128[2])')[:4]) == bar_selector
+    assert big_endian_to_int(sha3('sam(bytes,bool,uint256[])')[:4]) == sam_selector
+    assert big_endian_to_int(sha3('f(uint256,uint32[],bytes10,bytes)')[:4]) == f_selector
+
+    assert method_id('baz', ['uint32', 'bool']) == baz_selector
+    assert method_id('bar', ['fixed128x128[2]']) == bar_selector
+    assert method_id('sam', ['bytes', 'bool', 'uint256[]']) == sam_selector
+    assert method_id('f', ['uint256', 'uint32[]', 'bytes10', 'bytes']) == f_selector
+
+    assert method_id('bar', ['fixed[2]']) == bar_selector
+    assert method_id('sam', ['bytes', 'bool', 'uint[]']) == sam_selector
+    assert method_id('f', ['uint', 'uint32[]', 'bytes10', 'bytes']) == f_selector
 
 
-def test_abi_encode_signed_int():
-    assert abi.decode_abi(['int8'], abi.encode_abi(['int8'], [1]))[0] == 1
-    assert abi.decode_abi(['int8'], abi.encode_abi(['int8'], [-1]))[0] == -1
+def test_event():
+    event_abi = [{
+        'name': 'Test',
+        'anonymous': False,
+        'inputs': [
+            {'indexed': False, 'name': 'a', 'type': 'int256'},
+            {'indexed': False, 'name': 'b', 'type': 'int256'},
+        ],
+        'type': 'event',
+    }]
 
-def test_abi_encode_single_int():
-    assert abi.encode_single(['int', '256', []], -2**255) == (b'\x80'+b'\x00'*31)
-    assert abi.encode_single(['int', '256', []], (b'\x80'+b'\x00'*31)) == (b'\x80'+b'\x00'*31)
+    contract_abi = ContractTranslator(event_abi)
 
-    assert abi.encode_single(['int', '8', []], -128) == zpad(b'\x80', 32)
-    with pytest.raises(abi.ValueOutOfBounds):
-        assert abi.encode_single(['int', '8', []], -129)
+    normalized_name = normalize_name('Test')
+    encode_types = ['int256', 'int256']
+    id_ = event_id(normalized_name, encode_types)
 
-    assert abi.encode_single(['int', '8', []], 127) == zpad(b'\x7f', 32)
-    with pytest.raises(abi.ValueOutOfBounds):
-        assert abi.encode_single(['int', '8', []], 128)
+    topics = [id_]
+    data = encode_abi(encode_types, [1, 2])
 
-def test_abi_encode_single_ureal():
-    assert abi.encode_single(['ureal', '128x128', []], 0) == (b'\x00'*32)
-    assert abi.encode_single(['ureal', '128x128', []], 1.125) == (b'\x00'*15 + b'\x01\x20' + b'\x00'*15)
-    assert abi.encode_single(['ureal', '128x128', []], 2**127-1) == (b'\x7f' + b'\xff'*15 + b'\x00'*16)
+    result = contract_abi.decode_event(topics, data)
 
-def test_abi_encode_single_real():
-    assert abi.encode_single(['real', '128x128', []], 1.125) == (b'\x00'*15 + b'\x01\x20' + b'\x00'*15)
-    assert abi.encode_single(['real', '128x128', []], -1.125) == (b'\xff'*15 + b'\xfe' + b'\xe0' + b'\x00'*15)
+    assert result['_event_type'] == 'Test'
+    assert result['a'] == 1
+    assert result['b'] == 2
 
-def test_abi_encode_single_hash():
-    assert abi.encode_single(['hash', '8', []], b'\x00'*8) == b'\x00'*32
-    assert abi.encode_single(['hash', '8', []], '00'*8) == b'\x00'*32
 
-def test_abi_decode_single_hash():
-    typ = ['hash', '8', []]
-    assert b'\x01'*8 == abi.decode_single(typ, abi.encode_single(typ, b'\x01'*8))
+def test_decint():
+    assert decint(True) == 1
+    assert decint(False) == 0
+    assert decint(None) == 0
 
-def test_abi_decode_single_bytes():
-    typ = ['bytes', '8', []]
-    assert (b'\x01\x02' + b'\x00'*6) == abi.decode_single(typ, abi.encode_single(typ, b'\x01\x02'))
+    # unsigned upper boundary
+    assert decint(2 ** 256 - 1, signed=False) == 2 ** 256 - 1
+    assert decint(int_to_big_endian(2 ** 256 - 1), signed=False) == 2 ** 256 - 1
 
-    typ = ['bytes', '', []]
-    assert b'\x01\x02' == abi.decode_single(typ, abi.encode_single(typ, b'\x01\x02'))
+    with pytest.raises(EncodingError):
+        decint(2 ** 256, signed=False)
+        decint(int_to_big_endian(2 ** 256), signed=False)
 
-def test_abi_encode_single_prefixed_address():
-    prefixed_address = '0x' + '0'*40
-    assert abi.encode_single(['address', '', []], prefixed_address) == b'\x00' * 32
+    # unsigned lower boundary
+    assert decint(0) == 0
+    assert decint(int_to_big_endian(0)) == 0
+    with pytest.raises(EncodingError):
+        decint(-1, signed=False)
+        decint(int_to_big_endian(-1), signed=False)
 
-def test_abi_decode_single_real():
-    real_data = abi.encode_single(['real', '128x128', []], 1)
-    assert abi.decode_single(['real', '128x128', []], real_data) == 1
+    # signed upper boundary
+    assert decint(2 ** 255 - 1, signed=True) == 2 ** 255 - 1
+    assert decint(int_to_big_endian(2 ** 255 - 1), signed=True) == 2 ** 255 - 1
 
-    real_data = abi.encode_single(['real', '128x128', []], 2**127-1)
-    assert abi.decode_single(['real', '128x128', []], real_data) == (2**127-1)*1.0
+    with pytest.raises(EncodingError):
+        decint(2 ** 255, signed=True)
+        decint(int_to_big_endian(2 ** 255), signed=True)
 
-    real_data = abi.encode_single(['real', '128x128', []], -1)
-    assert abi.decode_single(['real', '128x128', []], real_data) == -1
+    # signed lower boundary
+    assert decint(-2 ** 255, signed=True) == -2 ** 255
+    # assert decint(int_to_big_endian(-2 ** 255), signed=True) == -2 ** 255
+    with pytest.raises(EncodingError):
+        decint(-2 ** 255 - 1, signed=True)
+        # decint(int_to_big_endian(-2 ** 255 - 1), signed=True)
 
-    real_data = abi.encode_single(['real', '128x128', []], -2**127)
-    assert abi.decode_single(['real', '128x128', []], real_data) == -2**127
 
-# Will be parametrized fron json fixtures
-def test_state(filename, testname, testdata):
+def test_encode_int():
+    int8 = ('int', '8', [])
+    int32 = ('int', '32', [])
+    int256 = ('int', '256', [])
+
+    int256_maximum = (
+        '\x7f\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+    )
+    int256_minimum = (
+        '\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    )
+    int256_128 = (
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x80'
+    )
+    int256_2_to_31 = (
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x80\x00\x00\x00'
+    )
+    int256_negative_one = (
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+    )
+
+    assert encode_single(int256, int256_minimum) == int256_minimum
+
+    assert encode_single(int8, 0) == zpad('\x00', 32)
+    assert encode_single(int8, 2 ** 7 - 1) == zpad('\x7f', 32)
+    assert encode_single(int8, -1) == zpad('\xff', 32)
+    assert encode_single(int8, -2 ** 7) == zpad('\x80', 32)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(int8, 128)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(int8, -129)
+
+    assert encode_single(int32, 0) == zpad('\x00', 32)
+    assert encode_single(int32, 2 ** 7 - 1) == zpad('\x7f', 32)
+    assert encode_single(int32, 2 ** 31 - 1) == zpad('\x7f\xff\xff\xff', 32)
+    assert encode_single(int32, -1) == zpad('\xff\xff\xff\xff', 32)
+    assert encode_single(int32, -2 ** 7) == zpad('\xff\xff\xff\x80', 32)
+    assert encode_single(int32, -2 ** 31) == zpad('\x80\x00\x00\x00', 32)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(int32, 2 ** 32)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(int32, -(2 ** 32))
+
+    assert encode_single(int256, 0) == zpad('\x00', 32)
+    assert encode_single(int256, 2 ** 7 - 1) == zpad('\x7f', 32)
+    assert encode_single(int256, 2 ** 31 - 1) == zpad('\x7f\xff\xff\xff', 32)
+    assert encode_single(int256, 2 ** 255 - 1) == int256_maximum
+    assert encode_single(int256, -1) == int256_negative_one
+    assert encode_single(int256, -2 ** 7) == int256_128
+    assert encode_single(int256, -2 ** 31) == int256_2_to_31
+    assert encode_single(int256, -2 ** 255) == int256_minimum
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(int256, 2 ** 256)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(int256, -(2 ** 256))
+
+
+def test_encode_uint():
+    uint8 = ('uint', '8', [])
+    uint32 = ('uint', '32', [])
+    uint256 = ('uint', '256', [])
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(uint8, -1)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(uint32, -1)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(uint256, -1)
+
+    assert encode_single(uint8, 0) == zpad('\x00', 32)
+    assert encode_single(uint32, 0) == zpad('\x00', 32)
+    assert encode_single(uint256, 0) == zpad('\x00', 32)
+
+    assert encode_single(uint8, 1) == zpad('\x01', 32)
+    assert encode_single(uint32, 1) == zpad('\x01', 32)
+    assert encode_single(uint256, 1) == zpad('\x01', 32)
+
+    assert encode_single(uint8, 2 ** 8 - 1) == zpad('\xff', 32)
+    assert encode_single(uint32, 2 ** 8 - 1) == zpad('\xff', 32)
+    assert encode_single(uint256, 2 ** 8 - 1) == zpad('\xff', 32)
+
+    assert encode_single(uint32, 2 ** 32 - 1) == zpad('\xff\xff\xff\xff', 32)
+    assert encode_single(uint256, 2 ** 32 - 1) == zpad('\xff\xff\xff\xff', 32)
+
+    uint256_maximum = (
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+    )
+    assert encode_single(uint256, 2 ** 256 - 1) == uint256_maximum
+
+
+def test_encode_bool():
+    bool_ = ('bool', '', [])
+    uint8 = ('uint', '8', [])
+
+    assert encode_single(bool_, True) == zpad('\x01', 32)
+    assert encode_single(bool_, False) == zpad('\x00', 32)
+
+    assert encode_single(bool_, True) == encode_single(uint8, 1)
+    assert encode_single(bool_, False) == encode_single(uint8, 0)
+
+
+def test_encode_fixed():
+    fixed128x128 = ('fixed', '128x128', [])
+
+    _2_125 = (
+        '00000000000000000000000000000002'
+        '20000000000000000000000000000000'
+    ).decode('hex')
+
+    _8_5 = (
+        '00000000000000000000000000000008'
+        '80000000000000000000000000000000'
+    ).decode('hex')
+
+    assert encode_single(fixed128x128, 2.125) == _2_125
+    assert encode_single(fixed128x128, 8.5) == _8_5
+
+    assert encode_single(fixed128x128, 1.125) == (b'\x00'*15 + b'\x01\x20' + b'\x00'*15)
+    assert encode_single(fixed128x128, -1.125) == (b'\xff'*15 + b'\xfe' + b'\xe0' + b'\x00'*15)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(fixed128x128, 2 ** 127)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(fixed128x128, -2 ** 127 - 1)
+
+
+def test_encoded_ufixed():
+    ufixed128x128 = ('ufixed', '128x128', [])
+
+    _2_125 = (
+        '00000000000000000000000000000002'
+        '20000000000000000000000000000000'
+    ).decode('hex')
+
+    _8_5 = (
+        '00000000000000000000000000000008'
+        '80000000000000000000000000000000'
+    ).decode('hex')
+
+    assert encode_single(ufixed128x128, 2.125) == _2_125
+    assert encode_single(ufixed128x128, 8.5) == _8_5
+
+    assert encode_single(ufixed128x128, 0) == (b'\x00'*32)
+    assert encode_single(ufixed128x128, 1.125) == (b'\x00'*15 + b'\x01\x20' + '\x00'*15)
+    assert encode_single(ufixed128x128, 2**127-1) == (b'\x7f' + b'\xff'*15 + b'\x00'*16)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(ufixed128x128, 2 ** 128 + 1)
+
+    with pytest.raises(ValueOutOfBounds):
+        encode_single(ufixed128x128, -1)
+
+
+def test_encode_dynamic_bytes():
+    dynamic_bytes = ('bytes', '', [])
+    uint256 = ('uint', '256', [])
+
+    # only the size of the bytes
+    assert encode_single(dynamic_bytes, '') == zpad('\x00', 32)
+
+    a = encode_single(uint256, 1) + rzpad('\x61', 32)
+    assert encode_single(dynamic_bytes, '\x61') == a
+
+    dave_bin = (
+        '0000000000000000000000000000000000000000000000000000000000000004'
+        '6461766500000000000000000000000000000000000000000000000000000000'
+    ).decode('hex')
+    dave = encode_single(uint256, 4) + rzpad('\x64\x61\x76\x65', 32)
+    assert encode_single(dynamic_bytes, '\x64\x61\x76\x65') == dave_bin
+    assert encode_single(dynamic_bytes, '\x64\x61\x76\x65') == dave
+
+
+def test_encode_dynamic_string():
+    string = ('string', '', [])
+    uint256 = ('uint', '256', [])
+
+    a = u'ã'
+    a_utf8 = a.encode('utf8')
+
+    with pytest.raises(ValueError):
+        encode_single(string, a.encode('latin'))
+
+    a_encoded = encode_single(uint256, len(a_utf8)) + rzpad(a_utf8, 32)
+    assert encode_single(string, a.encode('utf8')) == a_encoded
+
+
+def test_encode_hash():
+    hash8 = ('hash', '8', [])
+
+    assert encode_single(hash8, b'\x00' * 8) == b'\x00' * 32
+    assert encode_single(hash8, '00'*8) == b'\x00'*32
+
+
+def test_encode_address():
+    prefixed_address = '0x' + '0' * 40
+    assert encode_single(['address', '', []], prefixed_address) == b'\x00' * 32
+
+
+def test_encode_decode_int():
+    int8 = ('int', '8', [])
+    int32 = ('int', '32', [])
+    int256 = ('int', '256', [])
+
+    int8_values = [
+        1, -1,
+        127, -128,
+    ]
+    int32_values = [
+        1, -1,
+        127, -128,
+        2 ** 31 - 1, -2 ** 31,
+    ]
+    int256_values = [
+        1, -1,
+        127, -128,
+        2 ** 31 - 1, -2 ** 31,
+        2 ** 255 - 1, -2 ** 255,
+    ]
+
+    for value in int8_values:
+        assert encode_abi(['int8'], [value]) == encode_single(int8, value)
+        assert decode_abi(['int8'], encode_abi(['int8'], [value]))[0] == value
+
+    for value in int32_values:
+        assert encode_abi(['int32'], [value]) == encode_single(int32, value)
+        assert decode_abi(['int32'], encode_abi(['int32'], [value]))[0] == value
+
+    for value in int256_values:
+        assert encode_abi(['int256'], [value]) == encode_single(int256, value)
+        assert decode_abi(['int256'], encode_abi(['int256'], [value]))[0] == value
+
+
+def test_encode_decode_bool():
+    assert decode_abi(['bool'], encode_abi(['bool'], [True]))[0] is True
+    assert decode_abi(['bool'], encode_abi(['bool'], [False]))[0] is False
+
+
+def test_encode_decode_fixed():
+    fixed128x128 = ('fixed', '128x128', [])
+
+    fixed_data = encode_single(fixed128x128, 1)
+    assert decode_single(fixed128x128, fixed_data) == 1
+
+    fixed_data = encode_single(fixed128x128, 2**127-1)
+    assert decode_single(fixed128x128, fixed_data) == (2**127-1)*1.0
+
+    fixed_data = encode_single(fixed128x128, -1)
+    assert decode_single(fixed128x128, fixed_data) == -1
+
+    fixed_data = encode_single(fixed128x128, -2**127)
+    assert decode_single(fixed128x128, fixed_data) == -2**127
+
+
+def test_encode_decode_bytes():
+    bytes8 = ('bytes', '8', [])
+    dynamic_bytes = ('bytes', '', [])
+
+    assert decode_single(bytes8, encode_single(bytes8, b'\x01\x02')) == (b'\x01\x02' + b'\x00' * 6)
+    assert decode_single(dynamic_bytes, encode_single(dynamic_bytes, b'\x01\x02')) == b'\x01\x02'
+
+
+def test_encode_decode_hash():
+    hash8 = ('hash', '8', [])
+
+    hash1 = b'\x01' * 8
+    assert hash1 == decode_single(hash8, encode_single(hash8, hash1))
+
+
+def test_encode_decode_address():
+    address1 = b'\x11' * 20
+    address2 = b'\x22' * 20
+    address3 = b'\x33' * 20
+
+    all_addresses = [
+        address1,
+        address2,
+        address3,
+    ]
+    all_addresses_encoded = [
+        address1.encode('hex'),
+        address2.encode('hex'),
+        address3.encode('hex'),
+    ]
+
+    assert decode_abi(['address'], encode_abi(['address'], [address1]))[0] == address1.encode('hex')
+
+    addresses_encoded_together = encode_abi(['address[]'], [all_addresses])
+    assert decode_abi(['address[]'], addresses_encoded_together)[0] == all_addresses_encoded
+
+    address_abi = ['address', 'address', 'address']
+    addreses_encoded_splited = encode_abi(address_abi, all_addresses)
+    assert decode_abi(address_abi, addreses_encoded_splited) == all_addresses_encoded
+
+
+def test_state(filename, testname, testdata):  # pylint: disable=unused-argument
+    # test data generated by testutils.generate_test_params
     testutils.check_abi_test(testutils.fixture_to_bytes(testdata))
 
 

--- a/ethereum/tests/test_contracts.py
+++ b/ethereum/tests/test_contracts.py
@@ -1089,7 +1089,7 @@ def kall(a:arr, b, c:arr, d:str, e):
 def test_multiarg_code():
     s = tester.state()
     c = s.abi_contract(multiarg_code)
-    o = c.kall([1, 2, 3], 4, [5, 6, 7], "doge", 8)
+    o = c.kall([1, 2, 3], 4, [5, 6, 7], b"doge", 8)
     assert o == [862541, safe_ord('d') + safe_ord('o') + safe_ord('g'), 4]
 
 peano_code = """
@@ -1385,7 +1385,7 @@ def mcopy_test(foo:str, a, b, c):
 def test_mcopy():
     s = tester.state()
     c = s.abi_contract(mcopy_code)
-    assert c.mcopy_test("123", 5, 6, 259) == \
+    assert c.mcopy_test(b"123", 5, 6, 259) == \
         b'\x00'*31+b'\x05'+b'\x00'*31+b'\x06'+b'\x00'*30+b'\x01\x03'+b'123'
 
 
@@ -1499,7 +1499,7 @@ def test_double_array():
     s = tester.state()
     c = s.abi_contract(double_array_code)
     assert c.foo([1, 2, 3], [4, 5, 6, 7]) == [123, 4567]
-    assert c.bar([1, 2, 3], "moo", [4, 5, 6, 7]) == [123, 4567]
+    assert c.bar([1, 2, 3], b"moo", [4, 5, 6, 7]) == [123, 4567]
 
 
 abi_logging_code = """
@@ -1533,7 +1533,7 @@ def test_abi_logging():
     c.test_frog(5)
     assert o == [{"_event_type": b"frog", "y": 5}]
     o.pop()
-    c.test_moose(7, "nine", 11, [13, 15, 17])
+    c.test_moose(7, b"nine", 11, [13, 15, 17])
     assert o == [{"_event_type": b"moose", "a": 7, "b": b"nine",
                  "c": 11, "d": [13, 15, 17]}]
     o.pop()

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -162,7 +162,33 @@ def normalize_address(x, allow_blank=False):
 
 
 def zpad(x, l):
+    """ Left zero pad value `x` at least to length `l`.
+
+    >>> zpad('', 1)
+    '\x00'
+    >>> zpad('\xca\xfe', 4)
+    '\x00\x00\xca\xfe'
+    >>> zpad('\xff', 1)
+    '\xff'
+    >>> zpad('\xca\xfe', 2)
+    '\xca\xfe'
+    """
     return b'\x00' * max(0, l - len(x)) + x
+
+
+def rzpad(value, total_length):
+    """ Right zero pad value `x` at least to length `l`.
+
+    >>> zpad('', 1)
+    '\x00'
+    >>> zpad('\xca\xfe', 4)
+    '\xca\xfe\x00\x00'
+    >>> zpad('\xff', 1)
+    '\xff'
+    >>> zpad('\xca\xfe', 2)
+    '\xca\xfe'
+    """
+    return value + b'\x00' * max(0, total_length - len(value))
 
 
 def zunpad(x):


### PR DESCRIPTION
- changed the type real to fixed
- expanded the types handled by the _canonical_type function
- added extensive tests for int/uint types
- added tests for function selectors
- added logic to parse logs that don't depends on a processblock.Log
  instance
- added documentation for the encode_single function
- added function to zero pad to the right

breaking changes:
- `decint` raises if value is a string and out-of-bounds
- `encode_single`:
  - `int` and `uint` raises ValueOutOfBounds instead of EncodingError
  - `string` raises if the supplied value is not a valid utf8
  - `int`, `uint`, `fixed`, and `ufixed` raises if the type `sub` is
  invalid
  - renamed type `real` to `fixed`