### PR TITLE
Allow setting of a specific solc binary

### DIFF
--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -22,6 +22,11 @@ def get_compiler_path():
     This funtion will search for the solc binary in the $PATH and return the
     path of the first executable occurence.
     """
+    # If the user provides a specific solc binary let's use that
+    given_binary = os.environ.get('SOLC_BINARY')
+    if given_binary:
+        return given_binary
+
     for path in os.getenv('PATH', '').split(os.pathsep):
         path = path.strip('"')
         executable_path = os.path.join(path, BINARY)


### PR DESCRIPTION
Via the use of the `SOLC_BINARY` environment variable the user can now
set a specific path to his solc executable if for example said user is
compiling solidity from source.