### PR TITLE
Py3 cool checksum

### DIFF
--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -142,6 +142,11 @@ def add_cool_checksum(addr):
 
     o = ''
     h = encode_hex(sha3(addr_hex))
+    if not isinstance(addr_hex, str):
+        # py3 bytes sequence
+        addr_hex = list(chr(c) for c in addr_hex)
+        h = list(chr(c) for c in h)
+
     for i, c in enumerate(addr_hex):
         if c in '0123456789':
             o += c

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -68,8 +68,10 @@ isnumeric = is_numeric
 def mk_contract_address(sender, nonce):
     return sha3(rlp.encode([normalize_address(sender), nonce]))[12:]
 
+
 def mk_metropolis_contract_address(sender, initcode):
     return sha3(normalize_address(sender) + initcode)[12:]
+
 
 def safe_ord(value):
     if isinstance(value, int):
@@ -115,6 +117,7 @@ def int_to_32bytearray(i):
 
 sha3_count = [0]
 
+
 def sha3(seed):
     sha3_count[0] += 1
     return sha3_256(to_string(seed))
@@ -136,6 +139,7 @@ def add_checksum(x):
         return x
     return x + sha3(x)[:4]
 
+
 def add_cool_checksum(addr):
     addr = normalize_address(addr)
     addr_hex = encode_hex(addr)
@@ -152,13 +156,15 @@ def add_cool_checksum(addr):
             o += c
         else:
             o += c.lower() if h[i] in '01234567' else c.upper()
-    return '0x'+o
+    return '0x' + o
+
 
 def check_and_strip_checksum(x):
     if len(x) in (40, 48):
         x = decode_hex(x)
     assert len(x) == 24 and sha3(x[:20])[:4] == x[-4:]
     return x[:20]
+
 
 def check_and_strip_cool_checksum(addr):
     assert add_cool_checksum(addr.lower()) == addr


### PR DESCRIPTION
the `cool_checksum` feature was not python 3 compatible. 
It is not in the critical path, so I added an `isinstance` check for handling the py3 case.