### PR TITLE
Add factory for tester.state with recent fork-level

### DIFF
--- a/ethereum/config.py
+++ b/ethereum/config.py
@@ -67,6 +67,9 @@ default_config = dict(
     ANTI_DOS_FORK_BLKNUM=2457000,
     CLEARING_FORK_BLKNUM=2 ** 98,
 )
+
+LATEST_APPLIED_FORK_BLKNUM = default_config.get('ANTI_DOS_FORK_BLKNUM')
+
 assert default_config['NEPHEW_REWARD'] == \
     default_config['BLOCK_REWARD'] // 32
 

--- a/ethereum/tester.py
+++ b/ethereum/tester.py
@@ -10,7 +10,7 @@ from rlp.utils import ascii_chr
 
 from ethereum import blocks, db, opcodes, processblock, transactions
 from ethereum.abi import ContractTranslator
-from ethereum.config import Env
+from ethereum.config import Env, LATEST_APPLIED_FORK_BLKNUM
 from ethereum.slogging import LogRecorder
 from ethereum._solidity import get_solidity
 from ethereum.utils import to_string, sha3, privtoaddr, int_to_addr
@@ -416,3 +416,23 @@ class state(object):
         self.block.header._mutable = True
         self.block._cached_rlp = None
         self.block.header._cached_rlp = None
+
+
+def latest_state(blknum=None, **kwargs):
+    """Helper, that generates a `tester.state` instance with a block number
+    above all applied forks on the main net (depends on
+    `ethereum.config.LATEST_APPLIED_FORK_BLKNUM`) + 1.
+
+    If `blknum` is given, this number will be used as block number instead.
+
+    Returns:
+        `tester.state` instance with adjusted block number
+    """
+    blockchain_state = state(**kwargs)
+
+    if blknum is not None:
+        blockchain_state.block.number = LATEST_APPLIED_FORK_BLKNUM + 1
+    else:
+        blockchain_state.block.number = blknum
+
+    return blockchain_state

--- a/ethereum/tester.py
+++ b/ethereum/tester.py
@@ -421,7 +421,7 @@ class state(object):
 def latest_state(blknum=None, **kwargs):
     """Helper, that generates a `tester.state` instance with a block number
     above all applied forks on the main net (depends on
-    `ethereum.config.LATEST_APPLIED_FORK_BLKNUM`) + 1.
+    `ethereum.config.LATEST_APPLIED_FORK_BLKNUM`).
 
     If `blknum` is given, this number will be used as block number instead.
 
@@ -430,9 +430,11 @@ def latest_state(blknum=None, **kwargs):
     """
     blockchain_state = state(**kwargs)
 
-    if blknum is not None:
-        blockchain_state.block.number = LATEST_APPLIED_FORK_BLKNUM + 1
+    if blknum is None:
+        blockchain_state.block.number = LATEST_APPLIED_FORK_BLKNUM
     else:
+        if not isinstance(blknum, int):
+            raise ValueError("blknum must be integer")
         blockchain_state.block.number = blknum
 
     return blockchain_state

--- a/ethereum/tests/test_tester.py
+++ b/ethereum/tests/test_tester.py
@@ -4,11 +4,20 @@ from os import path
 
 import pytest
 
-from ethereum.tester import state, ABIContract
+from ethereum.tester import (state, ABIContract, latest_state,
+                             LATEST_APPLIED_FORK_BLKNUM)
 from ethereum._solidity import get_solidity, compile_file
 
 SOLIDITY_AVAILABLE = get_solidity() is not None
 CONTRACTS_DIR = path.join(path.dirname(__file__), 'contracts')
+
+
+def test_latest_state():
+    assert latest_state().block.number == LATEST_APPLIED_FORK_BLKNUM
+    assert latest_state(blknum=42).block.number == 42
+    assert latest_state(blknum=0).block.number == 0
+    with pytest.raises(ValueError):
+        latest_state(blknum=[1])
 
 
 @pytest.mark.skipif(not SOLIDITY_AVAILABLE, reason='solc compiler not available')


### PR DESCRIPTION
A common pitfall for developers is using vanilla `tester.state` with contracts
that use more recent opcodes (ending up with `invalid opcode` errors).

The factory function `latest_state`, prepares the state for any developer with
the latest fork block number (as set in ethereum.config.LATEST_FORK_BLKNUMBER).

This way, legacy applications won't change their behavior, but newer users/
developers can be encouraged to just use `latest_state()`.
