### PR TITLE
fix sha3 assertion to compare bytes to bytes

### DIFF
--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -122,7 +122,7 @@ def sha3(seed):
     sha3_count[0] += 1
     return sha3_256(to_string(seed))
 
-assert encode_hex(sha3(b'')) == b'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
+assert to_string(encode_hex(sha3(b''))) == b'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
 
 
 def privtoaddr(x, extended=False):


### PR DESCRIPTION
### What was wrong?

This upstream change to `encode_hex` via [this commit](https://github.com/ethereum/pyrlp/commit/2ec0fe159652f2cf12794bd8c239a8823cf93579#diff-08365a27b3d167a1798206d64f6e3708) modified the function to return unicode/text rather than the previous behavior of always returning bytes.

### How was it fixed.

Modified the assertion to compare bytes to bytes by wrapping the `sha3` result in a call to `ethereum.utils.to_string` which coerces string values into a bytes representation.

#### Cute animal picture

![eb68d7000f282372c06954184f216ab2](https://cloud.githubusercontent.com/assets/824194/20688988/78ad2758-b580-11e6-8425-dc94288f0f00.jpeg)


