### PR TITLE
Wrap encode_hex to support changes to pyrlp 0.4.7

### DIFF
--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import ast
@@ -6,7 +6,8 @@ import re
 import warnings
 
 import yaml  # use yaml instead of json to get non unicode (works with ascii only data)
-from rlp.utils import decode_hex, encode_hex
+from rlp.utils import decode_hex
+from ethereum.utils import encode_hex
 
 from ethereum import utils
 from ethereum.utils import (

--- a/ethereum/blocks.py
+++ b/ethereum/blocks.py
@@ -9,7 +9,8 @@ import sys
 from collections import Iterable
 import rlp
 from rlp.sedes import big_endian_int, Binary, binary, CountableList
-from rlp.utils import decode_hex, encode_hex
+from rlp.utils import decode_hex
+from ethereum.utils import encode_hex
 from ethereum import pruning_trie as trie
 from ethereum.pruning_trie import Trie
 from ethereum.securetrie import SecureTrie

--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -6,7 +6,7 @@ from ethereum.refcount_db import RefcountDB
 from ethereum.db import OverlayDB
 from ethereum.utils import to_string, is_string
 import rlp
-from rlp.utils import encode_hex
+from ethereum.utils import encode_hex
 from ethereum import blocks
 from ethereum import processblock
 from ethereum.exceptions import VerificationFailed, InvalidTransaction

--- a/ethereum/ethash_utils.py
+++ b/ethereum/ethash_utils.py
@@ -6,7 +6,8 @@ except:
     import sha3 as _sha3
     sha3_256 = lambda x: _sha3.sha3_256(x).digest()
     sha3_512 = lambda x: _sha3.sha3_512(x).digest()
-from rlp.utils import decode_hex, encode_hex
+from rlp.utils import decode_hex
+from ethereum.utils import encode_hex
 import sys
 
 WORD_BYTES = 4                    # bytes in word

--- a/ethereum/fastvm.py
+++ b/ethereum/fastvm.py
@@ -13,7 +13,8 @@ import copy
 from ethereum import opcodes
 import time
 from ethereum.slogging import get_logger
-from rlp.utils import encode_hex, ascii_chr
+from rlp.utils import ascii_chr
+from ethereum.utils import encode_hex
 from ethereum.utils import to_string
 import numpy
 

--- a/ethereum/keys.py
+++ b/ethereum/keys.py
@@ -2,7 +2,8 @@ import os
 import pbkdf2
 import sys
 
-from rlp.utils import encode_hex, decode_hex
+from rlp.utils import decode_hex
+from ethereum.utils import encode_hex
 
 try:
     scrypt = __import__('scrypt')

--- a/ethereum/processblock.py
+++ b/ethereum/processblock.py
@@ -1,7 +1,8 @@
 import sys
 import rlp
 from rlp.sedes import CountableList, binary
-from rlp.utils import decode_hex, encode_hex, ascii_chr
+from rlp.utils import decode_hex, ascii_chr
+from ethereum.utils import encode_hex
 from ethereum import opcodes
 from ethereum import utils
 from ethereum import specials

--- a/ethereum/pruning_trie.py
+++ b/ethereum/pruning_trie.py
@@ -5,8 +5,9 @@ import rlp
 from ethereum import utils
 from ethereum.utils import to_string
 from ethereum.utils import is_string
+from ethereum.utils import encode_hex
 import copy
-from rlp.utils import decode_hex, encode_hex, ascii_chr, str_to_bytes
+from rlp.utils import decode_hex, ascii_chr, str_to_bytes
 import sys
 from ethereum.fast_rlp import encode_optimized
 rlp_encode = encode_optimized

--- a/ethereum/tests/profile_vm.py
+++ b/ethereum/tests/profile_vm.py
@@ -4,7 +4,7 @@ import ethereum.testutils as testutils
 import cProfile
 import pstats
 import time
-from rlp.utils import encode_hex
+from ethereum.utils import encode_hex
 from ethereum.utils import sha3, to_string
 from ethereum.slogging import get_logger
 logger = get_logger()

--- a/ethereum/tests/test_blocks.py
+++ b/ethereum/tests/test_blocks.py
@@ -1,7 +1,8 @@
 from ethereum import blocks, utils, db
 from ethereum.exceptions import VerificationFailed, InvalidTransaction
 import rlp
-from rlp.utils import decode_hex, encode_hex, str_to_bytes
+from rlp.utils import decode_hex,  str_to_bytes
+from ethereum.utils import encode_hex
 from rlp import DecodingError, DeserializationError
 import sys
 import ethereum.testutils as testutils

--- a/ethereum/tests/test_bloom.py
+++ b/ethereum/tests/test_bloom.py
@@ -5,7 +5,8 @@ import ethereum.utils as utils
 import ethereum.testutils as testutils
 import ethereum.bloom as bloom
 import os
-from rlp.utils import decode_hex, encode_hex, str_to_bytes
+from rlp.utils import decode_hex, str_to_bytes
+from ethereum.utils import encode_hex
 
 
 def check_testdata(data_keys, expected_keys):

--- a/ethereum/tests/test_chain.py
+++ b/ethereum/tests/test_chain.py
@@ -3,7 +3,8 @@ import ethereum.processblock as processblock
 import ethereum.blocks as blocks
 import ethereum.transactions as transactions
 import rlp
-from rlp.utils import decode_hex, encode_hex
+from rlp.utils import decode_hex
+from ethereum.utils import encode_hex
 import ethereum.ethpow as ethpow
 import ethereum.utils as utils
 from ethereum.chain import Chain

--- a/ethereum/tests/test_genesis.py
+++ b/ethereum/tests/test_genesis.py
@@ -5,7 +5,7 @@ import ethereum.blocks as blocks
 import ethereum.testutils as testutils
 from ethereum.testutils import fixture_to_bytes
 import ethereum.utils as utils
-from rlp.utils import encode_hex
+from ethereum.utils import encode_hex
 from ethereum.tests.utils import new_env
 from ethereum.slogging import get_logger
 logger = get_logger()

--- a/ethereum/tests/test_solidity.py
+++ b/ethereum/tests/test_solidity.py
@@ -1,9 +1,9 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from os import path
 
 import pytest
 
-from rlp.utils import encode_hex
+from ethereum.utils import encode_hex
 
 from ethereum import tester
 from ethereum import utils

--- a/ethereum/tests/test_transactions.py
+++ b/ethereum/tests/test_transactions.py
@@ -1,7 +1,8 @@
 import ethereum.transactions as transactions
 import ethereum.utils as utils
 import rlp
-from rlp.utils import decode_hex, encode_hex, str_to_bytes
+from rlp.utils import decode_hex, str_to_bytes
+from ethereum.utils import encode_hex
 import ethereum.testutils as testutils
 from ethereum.testutils import fixture_to_bytes
 import ethereum.config as config

--- a/ethereum/tests/test_trie.py
+++ b/ethereum/tests/test_trie.py
@@ -5,7 +5,8 @@ import ethereum.trie as trie
 import ethereum.db as db
 import itertools
 from ethereum.slogging import get_logger
-from rlp.utils import decode_hex, encode_hex
+from rlp.utils import decode_hex
+from ethereum.utils import encode_hex
 from ethereum.abi import is_string
 from ethereum.testutils import fixture_to_bytes
 logger = get_logger()

--- a/ethereum/testutils.py
+++ b/ethereum/testutils.py
@@ -4,7 +4,8 @@ from ethereum import tester as t
 from ethereum import blocks, utils, transactions, vm, abi, opcodes
 from ethereum.exceptions import InvalidTransaction
 import rlp
-from rlp.utils import decode_hex, encode_hex, ascii_chr, str_to_bytes
+from rlp.utils import decode_hex, ascii_chr, str_to_bytes
+from ethereum.utils import encode_hex
 from ethereum import processblock as pb
 import copy
 from ethereum.db import EphemDB

--- a/ethereum/transactions.py
+++ b/ethereum/transactions.py
@@ -1,8 +1,9 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 import rlp
 from bitcoin import encode_pubkey, N, encode_privkey
 from rlp.sedes import big_endian_int, binary
-from rlp.utils import encode_hex, str_to_bytes, ascii_chr
+from rlp.utils import str_to_bytes, ascii_chr
+from ethereum.utils import encode_hex
 from secp256k1 import PublicKey, ALL_FLAGS, PrivateKey
 
 from ethereum.exceptions import InvalidTransaction

--- a/ethereum/trie.py
+++ b/ethereum/trie.py
@@ -5,7 +5,8 @@ from ethereum import utils
 from ethereum.utils import to_string
 from ethereum.abi import is_string
 import copy
-from rlp.utils import decode_hex, encode_hex, ascii_chr, str_to_bytes
+from rlp.utils import decode_hex, ascii_chr, str_to_bytes
+from ethereum.utils import encode_hex
 from ethereum.fast_rlp import encode_optimized
 rlp_encode = encode_optimized
 

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -8,7 +8,7 @@ from bitcoin import privtopub
 import sys
 import rlp
 from rlp.sedes import big_endian_int, BigEndianInt, Binary
-from rlp.utils import decode_hex, encode_hex, ascii_chr, str_to_bytes
+from rlp.utils import decode_hex, encode_hex as _encode_hex, ascii_chr, str_to_bytes
 import random
 
 big_endian_to_int = lambda x: big_endian_int.deserialize(str_to_bytes(x).lstrip(b'\x00'))
@@ -38,6 +38,8 @@ if sys.version_info.major == 2:
     def bytearray_to_bytestr(value):
         return bytes(''.join(chr(c) for c in value))
 
+    encode_hex = _encode_hex
+
 else:
     is_numeric = lambda x: isinstance(x, int)
     is_string = lambda x: isinstance(x, bytes)
@@ -61,6 +63,17 @@ else:
 
     def bytearray_to_bytestr(value):
         return bytes(value)
+
+    # returns encode_hex behaviour back to pre rlp-0.4.7 behaviour
+    # detect if this is necessary (i.e. what rlp version is running)
+    if isinstance(_encode_hex(b''), bytes):
+        encode_hex = _encode_hex
+    else:
+        # if using a newer version of rlp, wrap the encode so it
+        # returns a byte string
+        def encode_hex(b):
+            return _encode_hex(b).encode('utf-8')
+
 
 isnumeric = is_numeric
 

--- a/ethereum/vm.py
+++ b/ethereum/vm.py
@@ -7,7 +7,8 @@ import copy
 from ethereum import utils
 from ethereum import opcodes
 from ethereum.slogging import get_logger
-from rlp.utils import encode_hex, ascii_chr
+from rlp.utils import ascii_chr
+from ethereum.utils import encode_hex
 from ethereum.utils import to_string
 
 log_log = get_logger('eth.vm.log')


### PR DESCRIPTION
Fixes #421 

In pyrlp 0.4.7 encode_hex was changed to return a normal string instead
of a byte string. In python3 the pyethereum code expects encode_hex to
return a byte string so this was a breaking change.

This commit fixes it by checking the version of pyrlp by checking
encode_hex's return type, and if it's not a byte string wraps encode_hex
with a function that will encode the string into a byte string.

NOTE: I think it may actually be better to update all the codebase to support rlp 0.4.7, and change the wrapper to instead support older versions, but this requires more understanding of this internals of the project than i currently have and I think this provides a suitable solution to this in the mean time.