### PR TITLE
compile_code: raise exception when solc missing

### DIFF
--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -17,6 +17,10 @@ class CompileError(Exception):
     pass
 
 
+class SolcMissing(Exception):
+    pass
+
+
 def get_compiler_path():
     """ Return the path to the solc compiler.
 
@@ -296,7 +300,10 @@ def compile_last_contract(filepath, libraries=None, combined='bin,abi', optimize
 
 def compile_code(sourcecode, libraries=None, combined='bin,abi', optimize=True, extra_args=None):
     args = solc_arguments(libraries=libraries, combined=combined, optimize=optimize, extra_args=extra_args)
-    args.insert(0, get_compiler_path())
+    compiler = get_compiler_path()
+    if compiler is None:
+        raise SolcMissing("solc not found")
+    args.insert(0, compiler)
 
     process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdoutdata, stderrdata = process.communicate(input=utils.to_string(sourcecode))

--- a/ethereum/tests/test_solidity.py
+++ b/ethereum/tests/test_solidity.py
@@ -269,3 +269,10 @@ def test_extra_args():
         extra_args=["--optimize-runs", "100"]
     )
     assert bytecode_is_generated(contract_info, 'foo')
+
+def test_missing_solc(monkeypatch):
+    monkeypatch.setattr(_solidity, 'get_compiler_path', lambda: None)
+    assert _solidity.get_compiler_path() is None
+    sample_sol_code = "contract SampleContract {}"
+    with pytest.raises(_solidity.SolcMissing):
+        _solidity.compile_code(sample_sol_code)


### PR DESCRIPTION
When solc is not installed, compile_code() would end up using None as the first element in the args list passed to subprocess.Popen(), causing it to crash with an AttributeError. This fixes that