### PR TITLE
Fix the solidity combined-json result key

### DIFF
--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -272,6 +272,17 @@ def solidity_get_contract_data(all_contracts, filepath, contract_name):
     return contract_data
 
 
+def solidity_get_contract_key(all_contracts, filepath, contract_name):
+    """ A backwards compatible method of getting the key to the all_contracts
+    dictionary for a particular contract"""
+    if contract_name in all_contracts:
+        return contract_name
+    else:
+        _, filename = os.path.split(filepath)
+        contract_key = filename + ":" + contract_name
+        return contract_key if contract_key in all_contracts else None
+
+
 def compile_contract(filepath, contract_name, libraries=None, combined='bin,abi', optimize=True, extra_args=None):
     all_contracts = compile_file(
         filepath,

--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -261,6 +261,17 @@ def compile_file(filepath, libraries=None, combined='bin,abi', optimize=True, ex
     return solc_parse_output(output)
 
 
+def solidity_get_contract_data(all_contracts, filepath, contract_name):
+    """ A backwards compatible method of getting the contract data out
+    of a solc --combined-json output"""
+    try:
+        contract_data = all_contracts[contract_name]
+    except:
+        _, filename = os.path.split(filepath)
+        contract_data = all_contracts[filename + ":" + contract_name]
+    return contract_data
+
+
 def compile_contract(filepath, contract_name, libraries=None, combined='bin,abi', optimize=True, extra_args=None):
     all_contracts = compile_file(
         filepath,
@@ -269,12 +280,7 @@ def compile_contract(filepath, contract_name, libraries=None, combined='bin,abi'
         optimize=optimize,
         extra_args=extra_args
     )
-    try:
-        contract_data = all_contracts[contract_name]
-    except:
-        _, filename = os.path.split(filepath)
-        contract_data = all_contracts[filename + ":" + contract_name]
-    return contract_data
+    return solidity_get_contract_data(all_contracts, filepath, contract_name)
 
 
 def compile_last_contract(filepath, libraries=None, combined='bin,abi', optimize=True, extra_args=None):

--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -269,8 +269,12 @@ def compile_contract(filepath, contract_name, libraries=None, combined='bin,abi'
         optimize=optimize,
         extra_args=extra_args
     )
-    _, filename = os.path.split(filepath)
-    return all_contracts[filename + ":" + contract_name]
+    try:
+        contract_data = all_contracts[contract_name]
+    except:
+        _, filename = os.path.split(filepath)
+        contract_data = all_contracts[filename + ":" + contract_name]
+    return contract_data
 
 
 def compile_last_contract(filepath, libraries=None, combined='bin,abi', optimize=True, extra_args=None):

--- a/ethereum/_solidity.py
+++ b/ethereum/_solidity.py
@@ -269,8 +269,8 @@ def compile_contract(filepath, contract_name, libraries=None, combined='bin,abi'
         optimize=optimize,
         extra_args=extra_args
     )
-
-    return all_contracts[contract_name]
+    _, filename = os.path.split(filepath)
+    return all_contracts[filename + ":" + contract_name]
 
 
 def compile_last_contract(filepath, libraries=None, combined='bin,abi', optimize=True, extra_args=None):


### PR DESCRIPTION
In solidity version 0.4.9 the `--combined-json` output has
[changed](https://github.com/ethereum/solidity/blob/develop/Changelog.md#049-unreleased).

Now the dictionary key by which a contract is identified is the relative
filepath followed by ':' and finally follow by the contract name.