### PR TITLE
fix genesis timestamp

### DIFF
--- a/ethereum/blocks.py
+++ b/ethereum/blocks.py
@@ -1442,7 +1442,7 @@ def genesis(env, **kwargs):
         number=0,
         gas_limit=kwargs.get('gas_limit', env.config['GENESIS_GAS_LIMIT']),
         gas_used=0,
-        timestamp=kwargs.get('timestamp', 0),
+        timestamp=kwargs.get('timestamp', env.config['GENESIS_TIMESTAMP']),
         extra_data=kwargs.get('extra_data', env.config['GENESIS_EXTRA_DATA']),
         mixhash=kwargs.get('mixhash', env.config['GENESIS_MIXHASH']),
         nonce=kwargs.get('nonce', env.config['GENESIS_NONCE']),


### PR DESCRIPTION
Set the genesis block to the given timestamp (e.g. in a pyethapp [custom genesis](https://github.com/ethereum/pyethapp/wiki/Custom-genesis)). Needs the correct timestamp to get the right genesis block hash.