### PR TITLE
Adjust to pysha3 breaking changes

### DIFF
--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -3,7 +3,7 @@ try:
     sha3_256 = lambda x: keccak.new(digest_bits=256, data=x).digest()
 except:
     import sha3 as _sha3
-    sha3_256 = lambda x: _sha3.sha3_256(x).digest()
+    sha3_256 = lambda x: _sha3.keccak_256(x).digest()
 from bitcoin import privtopub
 import sys
 import rlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bitcoin
-pysha3
+pysha3>=1.0.1
 PyYAML
 repoze.lru
 pbkdf2


### PR DESCRIPTION
`pysha3` adjusted `sha3_256` to the newer standard. Since we rely on the `keccac`
version, we will now explicitely use `keccak_256` from `pysha3>=1.0.1`.

See: https://github.com/tiran/pysha3/blob/3b31ed7beaed82d1c5300621ad53b51a0fa3bf18/CHANGES.txt#L4-L11