### PR TITLE
Switch to static solc build in travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 python: 3.5
 sudo: required
 dist: trusty
-before_install:
-- sudo add-apt-repository -y ppa:ethereum/ethereum
-- sudo apt-get update
-- sudo apt-get install -y solc
 env:
   matrix:
   - TOX_ENV=py27
@@ -15,6 +11,18 @@ env:
     - COVERAGE_APPEND="--append"
     - secure: cKbIgpTJ1yjKLBxpCEiT6IH7NShDWZUE+BvnrAfc+ujCsR6LyLJcKxFQmKnWryJCqg7fp82Ep2bF2oDKzanAROar2xDY1SFGbai42seYMaFCw53YPGJ6u3VNCcfT0rN9BWgE7el/m4fjcD6CRsZYKArNNJbMX8csRt3uXXCFLso=
     - secure: "QyFPrxQHd2LlNQ6zNeTFYhgPmZaOHoWuywcgn8qaSOh6PklyFxHbexkwg0bl23JvtgNEZ1mCD8j0x1/ydSdtxgCFwK9SEL0h7aYuAq+OAIa/G18OPeTJMf7ASsb2QZdfkt9reFpUnjbadzHkuv+rqqb4bFnTJBKwB2LWzHPLhWg="
+    - SOLC_URL='https://github.com/brainbot-com/solidity-static/releases/download/v0.4.8/solc'
+    - SOLC_VERSION='0.4.8'
+  
+cache:
+  directories:
+    - $HOME/.bin
+
+before_install:
+  - mkdir -p $HOME/.bin
+  - export PATH=$PATH:$HOME/.bin
+  - ./.travis/download_solc.sh
+
 install:
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox

--- a/.travis/download_solc.sh
+++ b/.travis/download_solc.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+
+fail() {
+    if [[ $- == *i* ]]; then
+       red=`tput setaf 1`
+       reset=`tput sgr0`
+
+       echo "${red}==> ${@}${reset}"
+    fi
+    exit 1
+}
+
+info() {
+    if [[ $- == *i* ]]; then
+        blue=`tput setaf 4`
+        reset=`tput sgr0`
+
+        echo "${blue}${@}${reset}"
+    fi
+}
+
+success() {
+    if [[ $- == *i* ]]; then
+        green=`tput setaf 2`
+        reset=`tput sgr0`
+        echo "${green}${@}${reset}"
+    fi
+
+}
+
+warn() {
+    if [[ $- == *i* ]]; then
+        yellow=`tput setaf 3`
+        reset=`tput sgr0`
+
+        echo "${yellow}${@}${reset}"
+    fi
+}
+
+[ -z "${SOLC_URL}" ] && fail 'missing SOLC_URL'
+[ -z "${SOLC_VERSION}" ] && fail 'missing SOLC_VERSION'
+
+if [ ! -x $HOME/.bin/solc-${SOLC_VERSION} ]; then
+    mkdir -p $HOME/.bin
+
+    curl -L $SOLC_URL > $HOME/.bin/solc-${SOLC_VERSION}
+    chmod 775 $HOME/.bin/solc-${SOLC_VERSION}
+
+    success "solc ${SOLC_VERSION} installed"
+else
+    info 'using cached solc'
+fi
+
+# always recreate the symlink since we dont know if it's pointing to a different
+# version
+[ -h $HOME/.bin/solc ] && unlink $HOME/.bin/solc
+ln -s $HOME/.bin/solc-${SOLC_VERSION} $HOME/.bin/solc


### PR DESCRIPTION
This allows for better control of the solidity version in CI.
The setup for using the static `solc` executable is borrowed from
the raiden project: https://github.com/raiden-network/raiden

For updating solc versions, adjust `SOLC_URL` and `SOLC_VERSION` in `.travis.yml`.

**3rd party dependency notice:** This makes use of static `solc` builds from
https://github.com/brainbot-com/solidity-static in travis CI