### PR TITLE
Install solc from zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
   - if [ -n "$SOLC_VERSION" ]; then sudo apt-get install -y tree unzip; fi
 install:
   - if [ -n "$SOLC_VERSION" ]; then /.$TRAVIS_BUILD_DIR/.travis/install_solc.sh; fi
-install:
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox
   - travis_retry pip install coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 python: 3.5
 sudo: required
 dist: trusty
-before_install:
-- sudo add-apt-repository -y ppa:ethereum/ethereum
-- sudo apt-get update
-- sudo apt-get install -y solc
 env:
   matrix:
   - TOX_ENV=py27
@@ -15,6 +11,18 @@ env:
     - COVERAGE_APPEND="--append"
     - secure: cKbIgpTJ1yjKLBxpCEiT6IH7NShDWZUE+BvnrAfc+ujCsR6LyLJcKxFQmKnWryJCqg7fp82Ep2bF2oDKzanAROar2xDY1SFGbai42seYMaFCw53YPGJ6u3VNCcfT0rN9BWgE7el/m4fjcD6CRsZYKArNNJbMX8csRt3uXXCFLso=
     - secure: "QyFPrxQHd2LlNQ6zNeTFYhgPmZaOHoWuywcgn8qaSOh6PklyFxHbexkwg0bl23JvtgNEZ1mCD8j0x1/ydSdtxgCFwK9SEL0h7aYuAq+OAIa/G18OPeTJMf7ASsb2QZdfkt9reFpUnjbadzHkuv+rqqb4bFnTJBKwB2LWzHPLhWg="
+    - SOLC_VERSION=0.4.8
+cache:
+  directories:
+    - $HOME/.bin
+    - $HOME/solc-versions
+before_install:
+  - mkdir -p $HOME/.bin
+  - export PATH=$PATH:$HOME/.bin
+  - if [ -n "$SOLC_VERSION" ]; then export LD_LIBRARY_PATH="$HOME/solc-versions/solc-$SOLC_VERSION"; fi
+  - if [ -n "$SOLC_VERSION" ]; then sudo apt-get install -y tree unzip; fi
+install:
+  - if [ -n "$SOLC_VERSION" ]; then /.$TRAVIS_BUILD_DIR/.travis/install_solc.sh; fi
 install:
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox

--- a/.travis/install_solc.sh
+++ b/.travis/install_solc.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Install solc 
+#
+
+set -e
+set -u
+
+mkdir -p $HOME/solc-versions/solc-$SOLC_VERSION
+cd solc-versions/solc-$SOLC_VERSION
+
+if [ ! -f solc ]
+then
+    git clone --recurse-submodules --branch v$SOLC_VERSION --depth 50 https://github.com/ethereum/solidity.git
+    ./solidity/scripts/install_deps.sh
+    wget https://github.com/ethereum/solidity/releases/download/v$SOLC_VERSION/solidity-ubuntu-trusty.zip
+    unzip solidity-ubuntu-trusty.zip
+    echo "Solidity installed at $TRAVIS_BUILD_DIR/solc-versions/solc-$SOLC_VERSION/solc"
+    tree $TRAVIS_BUILD_DIR/solc-versions/solc-$SOLC_VERSION
+fi
+
+if [ -f $HOME/.bin/solc ]
+then
+    rm $HOME/.bin/solc
+fi
+
+ln -s $HOME/solc-versions/solc-$SOLC_VERSION $HOME/.bin/solc

--- a/.travis/install_solc.sh
+++ b/.travis/install_solc.sh
@@ -7,7 +7,7 @@ set -e
 set -u
 
 mkdir -p $HOME/solc-versions/solc-$SOLC_VERSION
-cd solc-versions/solc-$SOLC_VERSION
+cd $HOME/solc-versions/solc-$SOLC_VERSION
 
 if [ ! -f solc ]
 then
@@ -15,8 +15,8 @@ then
     ./solidity/scripts/install_deps.sh
     wget https://github.com/ethereum/solidity/releases/download/v$SOLC_VERSION/solidity-ubuntu-trusty.zip
     unzip solidity-ubuntu-trusty.zip
-    echo "Solidity installed at $TRAVIS_BUILD_DIR/solc-versions/solc-$SOLC_VERSION/solc"
-    tree $TRAVIS_BUILD_DIR/solc-versions/solc-$SOLC_VERSION
+    echo "Solidity installed at $HOME/solc-versions/solc-$SOLC_VERSION/solc"
+    tree $HOME/solc-versions/solc-$SOLC_VERSION
 fi
 
 if [ -f $HOME/.bin/solc ]
@@ -24,4 +24,10 @@ then
     rm $HOME/.bin/solc
 fi
 
-ln -s $HOME/solc-versions/solc-$SOLC_VERSION $HOME/.bin/solc
+ln -s $HOME/solc-versions/solc-$SOLC_VERSION/solc $HOME/.bin/solc
+# Check path is correctly set up and echo version
+cd
+echo $PATH
+ls -al $HOME/.bin
+ls -al $(readlink -f $HOME/.bin/solc)
+solc --version


### PR DESCRIPTION
This is an alternative to #437 without the problem of a 3rd party release repository.

The method is borrowed from `py-solc` -- thanks @pipermerriam!