### PR TITLE
Add python3 support for test_chain.py

### DIFF
--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -1,4 +1,5 @@
 import time
+from builtins import range
 from ethereum import utils
 from ethereum.utils import parse_as_bin, big_endian_to_int
 from ethereum import parse_genesis_declaration
@@ -359,4 +360,3 @@ class Chain(object):
     @property
     def config(self):
         return self.env.config
-

--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -60,11 +60,11 @@ class Chain(object):
 
         self.head_hash = self.state.prev_headers[0].hash
         self.genesis = Block(self.state.prev_headers[0], [], [])
-        self.db.put('state:'.encode('utf8') + self.head_hash, self.state.trie.root_hash)
+        self.db.put(b'state:' + self.head_hash, self.state.trie.root_hash)
         self.db.put('GENESIS_NUMBER', str(self.state.block_number))
         self.db.put('GENESIS_HASH', self.state.prev_headers[0].hash)
         assert self.state.block_number == self.state.prev_headers[0].number
-        self.db.put('score:'.encode('utf8') + self.state.prev_headers[0].hash, "0")
+        self.db.put(b'score:' + self.state.prev_headers[0].hash, "0")
         self.db.put('GENESIS_STATE', json.dumps(self.state.to_snapshot()))
         self.db.put(self.head_hash, 'GENESIS')
         self.min_gasprice = kwargs.get('min_gasprice', 5 * 10**9)
@@ -91,7 +91,7 @@ class Chain(object):
         if self.db.get(blockhash) == 'GENESIS':
             return State.from_snapshot(json.loads(self.db.get('GENESIS_STATE')), self.env)
         state = State(env=self.env)
-        state.trie.root_hash = self.db.get('state:'.encode('utf8') + blockhash)
+        state.trie.root_hash = self.db.get(b'state:' + blockhash)
         block = rlp.decode(self.db.get(blockhash), Block)
         update_block_env_variables(state, block)
         state.gas_used = block.header.gas_used
@@ -142,14 +142,14 @@ class Chain(object):
     # parent hash and see that it is one of its children
     def add_child(self, child):
         try:
-            existing = self.db.get('child:'.encode('utf8') + child.header.prevhash)
+            existing = self.db.get(b'child:' + child.header.prevhash)
         except:
             existing = b''
         existing_hashes = []
         for i in range(0, len(existing), 32):
             existing_hashes.append(existing[i: i+32])
         if child.header.hash not in existing_hashes:
-            self.db.put('child:'.encode('utf8') + child.header.prevhash, existing + child.header.hash)
+            self.db.put(b'child:' + child.header.prevhash, existing + child.header.hash)
 
     def get_blockhash_by_number(self, number):
         try:
@@ -164,7 +164,7 @@ class Chain(object):
     def get_child_hashes(self, blockhash):
         o = []
         try:
-            data = self.db.get('child:'.encode('utf8') + blockhash)
+            data = self.db.get(b'child:' + blockhash)
             for i in range(0, len(data), 32):
                 o.append(data[i:i + 32])
             return o
@@ -182,14 +182,14 @@ class Chain(object):
     def get_score(self, block):
         if not block:
             return 0
-        key = 'score:'.encode('utf8') + block.header.hash
+        key = b'score:' + block.header.hash
         if key not in self.db:
             try:
                 parent_score = self.get_score(self.get_parent(block))
                 self.db.put(key, str(parent_score + block.difficulty +
                                      random.randrange(block.difficulty // 10**6 + 1)))
             except:
-                return int(self.db.get('score:'.encode('utf8') + block.prevhash))
+                return int(self.db.get(b'score:' + block.prevhash))
         return int(self.db.get(key))
 
     # These two functions should be called periodically so as to
@@ -235,10 +235,10 @@ class Chain(object):
                 log.info('Block %s with parent %s invalid, reason: %s' % (encode_hex(block.header.hash), encode_hex(block.header.prevhash), e))
                 return False
             self.db.put('block:' + str(block.header.number), block.header.hash)
-            self.db.put('state:'.encode('utf8') + block.header.hash, self.state.trie.root_hash)
+            self.db.put(b'state:' + block.header.hash, self.state.trie.root_hash)
             self.head_hash = block.header.hash
             for i, tx in enumerate(block.transactions):
-                self.db.put('txindex:'.encode('utf8') + tx.hash, rlp.encode([block.number, i]))
+                self.db.put(b'txindex:' + tx.hash, rlp.encode([block.number, i]))
         elif block.header.prevhash in self.env.db:
             log.info('Receiving block not on head, adding to secondary post state',
                      prevhash=encode_hex(block.header.prevhash))
@@ -248,7 +248,7 @@ class Chain(object):
             except (KeyError, ValueError) as e:  # FIXME add relevant exceptions here
                 log.info('Block %s with parent %s invalid, reason: %s' % (encode_hex(block.header.hash), encode_hex(block.header.prevhash), e))
                 return False
-            self.db.put('state:'.encode('utf8') + block.header.hash, temp_state.trie.root_hash)
+            self.db.put(b'state:' + block.header.hash, temp_state.trie.root_hash)
             block_score = self.get_score(block)
             # Replace the head
             if block_score > self.get_score(self.head):
@@ -272,13 +272,13 @@ class Chain(object):
                         self.db.delete(key)
                         orig_block_at_height = self.get_block(orig_at_height)
                         for tx in orig_block_at_height.transactions:
-                            if 'txindex:'.encode('utf8') + tx.hash in self.db:
-                                self.db.delete('txindex:'.encode('utf8') + tx.hash)
+                            if b'txindex:' + tx.hash in self.db:
+                                self.db.delete(b'txindex:' + tx.hash)
                     if i in new_chain:
                         new_block_at_height = new_chain[i]
                         self.db.put(key, new_block_at_height.header.hash)
                         for i, tx in enumerate(new_block_at_height.transactions):
-                            self.db.put('txindex:'.encode('utf8') + tx.hash,
+                            self.db.put(b'txindex:' + tx.hash,
                                         rlp.encode([new_block_at_height.number, i]))
                     if i not in new_chain and not orig_at_height:
                         break
@@ -335,8 +335,8 @@ class Chain(object):
     def get_transaction(self, tx):
         if not isinstance(tx, (str, bytes)):
             tx = tx.hash
-        if 'txindex:'.encode('utf8') + tx in self.db:
-            data = rlp.decode(self.db.get('txindex:'.encode('utf8') + tx))
+        if b'txindex:' + tx in self.db:
+            data = rlp.decode(self.db.get(b'txindex:' + tx))
             blk, index = self.get_block_by_number(
                 big_endian_to_int(data[0])), big_endian_to_int(data[1])
             tx = blk.transactions[index]

--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -1,5 +1,5 @@
 import time
-from itertools import count, islice
+import itertools
 from ethereum import utils
 from ethereum.utils import parse_as_bin, big_endian_to_int
 from ethereum import parse_genesis_declaration
@@ -264,7 +264,7 @@ class Chain(object):
                         break
                     b = self.get_parent(b)
                 replace_from = b.header.number
-                for i in islice(count(), replace_from, 2**63 - 1):
+                for i in itertools.count(replace_from):
                     log.info('Rewriting height %d' % i)
                     key = 'block:' + str(i)
                     orig_at_height = self.db.get(key) if key in self.db else None
@@ -325,7 +325,7 @@ class Chain(object):
         if frm is None:
             frm = int(self.db.get('GENESIS_NUMBER')) + 1
         chain = []
-        for i in islice(count(), frm, to):
+        for i in itertools.islice(itertools.count(), frm, to):
             h = self.get_blockhash_by_number(i)
             if not h:
                 return chain

--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -1,5 +1,5 @@
 import time
-from builtins import range
+from itertools import count, islice
 from ethereum import utils
 from ethereum.utils import parse_as_bin, big_endian_to_int
 from ethereum import parse_genesis_declaration
@@ -264,7 +264,7 @@ class Chain(object):
                         break
                     b = self.get_parent(b)
                 replace_from = b.header.number
-                for i in range(replace_from, 2**63 - 1):
+                for i in islice(count(), replace_from, 2**63 - 1):
                     log.info('Rewriting height %d' % i)
                     key = 'block:' + str(i)
                     orig_at_height = self.db.get(key) if key in self.db else None
@@ -325,7 +325,7 @@ class Chain(object):
         if frm is None:
             frm = int(self.db.get('GENESIS_NUMBER')) + 1
         chain = []
-        for i in range(frm, to):
+        for i in islice(count(), frm, to):
             h = self.get_blockhash_by_number(i)
             if not h:
                 return chain

--- a/ethereum/consensus_strategy.py
+++ b/ethereum/consensus_strategy.py
@@ -10,7 +10,7 @@ class ConsensusStrategy(object):
 
 def get_consensus_strategy(config):
     if config['CONSENSUS_STRATEGY'] in ('pow', 'ethpow', 'ethash', 'ethereum1'):
-        from ethpow_utils import ethereum1_check_header, ethereum1_validate_header, \
+        from ethereum.ethpow_utils import ethereum1_check_header, ethereum1_validate_header, \
                                  ethereum1_validate_uncle, ethereum1_pre_finalize_block, \
                                  ethereum1_post_finalize_block, ethereum1_setup_block
         return ConsensusStrategy(
@@ -23,7 +23,7 @@ def get_consensus_strategy(config):
             state_initialize=None
         )
     elif config['CONSENSUS_STRATEGY'] == 'casper':
-        from casper_utils import casper_validate_header, casper_state_initialize, casper_post_finalize_block, casper_setup_block
+        from ethereum.casper_utils import casper_validate_header, casper_state_initialize, casper_post_finalize_block, casper_setup_block
         return ConsensusStrategy(
             header_check=None,
             header_validate=casper_validate_header,

--- a/ethereum/tests/test_chain.py
+++ b/ethereum/tests/test_chain.py
@@ -212,9 +212,9 @@ def test_invalid_transaction(db):
 def test_prevhash(db):
     chain = Chain({}, difficulty=1, min_gasprice=0)
     L1 = mine_on_chain(chain)
-    assert chain.state.get_block_hash(0) != '\x00'*32
-    assert chain.state.get_block_hash(1) != '\x00'*32
-    assert chain.state.get_block_hash(2) == '\x00'*32
+    assert chain.state.get_block_hash(0) != b'\x00'*32
+    assert chain.state.get_block_hash(1) != b'\x00'*32
+    assert chain.state.get_block_hash(2) == b'\x00'*32
 
 
 def test_genesis_chain(db):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ PyYAML
 repoze.lru
 pbkdf2
 pycryptodome>=3.3.1
+future==0.16.0
 scrypt
 rlp>=0.4.7
 https://github.com/ethereum/ethash/tarball/master

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ PyYAML
 repoze.lru
 pbkdf2
 pycryptodome>=3.3.1
-future==0.16.0
 scrypt
 rlp>=0.4.7
 https://github.com/ethereum/ethash/tarball/master


### PR DESCRIPTION
This PR provides Python3 support for `chain.py`, `consensus_strategy.py`, and `test_chain.py`. I did this because the Casper contract is written in Viper, which can only be compiled using Python3. Therefore to add Casper support, it seemed like we should also have Python3 support.

I tested this and it passed in `Python 3.6.1` and `Python 2.7.10`.

# Changes
- Fix a bunch of Python3 bytes errors in `chain.py` & `test_chain.py`
- Remove relative imports in `consensus_strategy.py`
- Add [the package `future`](http://python-future.org/) to fix `Memory Error` when moving from `xrange()` to -> `range()` in Python2.7. I hate adding a new dependency but I wasn't able to find a cleaner solution.