### PR TITLE
Fixes bug in `is_string`.

### DIFF
--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -40,7 +40,7 @@ if sys.version_info.major == 2:
 
 else:
     is_numeric = lambda x: isinstance(x, int)
-    is_string = lambda x: isinstance(x, bytes)
+    is_string = lambda x: isinstance(x, str)
 
     def to_string(value):
         if isinstance(value, bytes):


### PR DESCRIPTION
I'm not sure why someone thought that `bytes` was the correct value here, but `is_string('hello')` returns false in Python 3 with the old code.