### PR TITLE
add .env to gitignore for personal pyenv, autoenv settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pyethereum/todo.txt
 pyethereum/monkeypatch.py
 .eggs
 .cache
+.env


### PR DESCRIPTION
Add '.env' file to .gitignore for personal [autoenv](https://github.com/kennethreitz/autoenv) settings

[autoenv](https://github.com/kennethreitz/autoenv) can auto-activating virtualenvs
If a directory contains a .env file, it will automatically be executed when you cd into it.