### PR TITLE
Fixed contracts and docstrings to triple-double-quotes

### DIFF
--- a/ethereum/__init__.py
+++ b/ethereum/__init__.py
@@ -42,7 +42,7 @@ if not __version__:
 
 # ########### endversion ##################
 
-'''from ethereum import utils
+"""from ethereum import utils
 from ethereum import trie
 from ethereum import securetrie
 from ethereum import blocks
@@ -51,4 +51,4 @@ from ethereum import processblock
 from ethereum import tester
 from ethereum import abi
 from ethereum import keys
-from ethereum import ethash'''
+from ethereum import ethash"""

--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -135,7 +135,7 @@ def event_id(name, encode_types):
 
 
 def decint(n, signed=False):  # pylint: disable=invalid-name,too-many-branches
-    ''' Decode an unsigned/signed integer. '''
+    """ Decode an unsigned/signed integer. """
 
     if isinstance(n, str):
         n = utils.to_string(n)
@@ -185,7 +185,7 @@ def decint(n, signed=False):  # pylint: disable=invalid-name,too-many-branches
 
 
 def encode_single(typ, arg):  # pylint: disable=too-many-return-statements,too-many-branches,too-many-statements,too-many-locals
-    ''' Encode `arg` as `typ`.
+    """ Encode `arg` as `typ`.
 
     `arg` will be encoded in a best effort manner, were necessary the function
     will try to correctly define the underlying binary representation (ie.
@@ -223,7 +223,7 @@ def encode_single(typ, arg):  # pylint: disable=too-many-return-statements,too-m
     Note:
         This function don't work with array types, for that use the `enc`
         function.
-    '''
+    """
     base, sub, _ = typ
 
     if base == 'uint':

--- a/ethereum/experimental/pruning_trie.py
+++ b/ethereum/experimental/pruning_trie.py
@@ -168,9 +168,9 @@ def unpack_to_nibbles(bindata):
 
 
 def starts_with(full, part):
-    ''' test whether the items in the part is
+    """ test whether the items in the part is
     the leading items of the full
-    '''
+    """
     if len(full) < len(part):
         return False
     return full[:len(part)] == part
@@ -200,11 +200,11 @@ def transient_trie_exception(*args):
 class Trie(object):
 
     def __init__(self, db, root_hash=BLANK_ROOT, transient=False):
-        '''it also present a dictionary like interface
+        """it also present a dictionary like interface
 
         :param db key value database
         :root: blank or trie node in form of [key, value] or [v0,v1..v15,v]
-        '''
+        """
         self.db = db  # Pass in a database object directly
         self.transient = transient
         if self.transient:
@@ -215,11 +215,11 @@ class Trie(object):
         self.journal = []
 
     # def __init__(self, dbfile, root_hash=BLANK_ROOT):
-    #     '''it also present a dictionary like interface
+    #     """it also present a dictionary like interface
 
     #     :param dbfile: key value database
     #     :root: blank or trie node in form of [key, value] or [v0,v1..v15,v]
-    #     '''
+    #     """
     #     if isinstance(dbfile, str):
     #         dbfile = os.path.abspath(dbfile)
     #         self.db = DB(dbfile)
@@ -251,8 +251,8 @@ class Trie(object):
 
     @property
     def root_hash(self):
-        '''always empty or a 32 bytes string
-        '''
+        """always empty or a 32 bytes string
+        """
         return self.get_root_hash()
 
     def get_root_hash(self):
@@ -311,8 +311,8 @@ class Trie(object):
         # return o
 
     def clear(self):
-        ''' clear all tree data
-        '''
+        """ clear all tree data
+        """
         self._delete_child_storage(self.root_node)
         self._delete_node_storage(self.root_node)
         self.root_node = BLANK_NODE
@@ -349,11 +349,11 @@ class Trie(object):
         return o
 
     def _get_node_type(self, node):
-        ''' get node type and content
+        """ get node type and content
 
         :param node: node in form of list, or BLANK_NODE
         :return: node type
-        '''
+        """
         if node == BLANK_NODE:
             return NODE_TYPE_BLANK
 
@@ -603,9 +603,9 @@ class Trie(object):
         return nibbles_to_bin(o) if o else None
 
     def _delete_node_storage(self, node, is_root=False):
-        '''delete storage
+        """delete storage
         :param node: node in form of list, or BLANK_NODE
-        '''
+        """
         if node == BLANK_NODE:
             return
         # assert isinstance(node, list)
@@ -645,8 +645,8 @@ class Trie(object):
 
     def _normalize_branch_node(self, node):
         # sys.stderr.write('nbn\n')
-        '''node should have only one item changed
-        '''
+        """node should have only one item changed
+        """
         not_blank_items_count = sum(1 for x in range(17) if node[x])
         assert not_blank_items_count >= 1
 
@@ -772,9 +772,9 @@ class Trie(object):
         assert False
 
     def delete(self, key):
-        '''
+        """
         :param key: a string with length of [0, 32]
-        '''
+        """
         if not is_string(key):
             raise Exception("Key must be string")
 
@@ -808,10 +808,10 @@ class Trie(object):
                 self.clear_all(self._decode_to_node(node[i]))
 
     def _get_size(self, node):
-        '''Get counts of (key, value) stored in this and the descendant nodes
+        """Get counts of (key, value) stored in this and the descendant nodes
 
         :param node: node in form of list, or BLANK_NODE
-        '''
+        """
         if node == BLANK_NODE:
             return 0
 
@@ -830,7 +830,7 @@ class Trie(object):
             return sum(sizes)
 
     def _to_dict(self, node):
-        '''convert (key, value) stored in this and the descendant nodes
+        """convert (key, value) stored in this and the descendant nodes
         to dict items.
 
         :param node: node in form of list, or BLANK_NODE
@@ -838,7 +838,7 @@ class Trie(object):
         .. note::
 
             Here key is in full form, rather than key of the individual node
-        '''
+        """
         if node == BLANK_NODE:
             return {}
 
@@ -894,12 +894,12 @@ class Trie(object):
             yield key, value
 
     def _iter_branch(self, node):
-        '''yield (key, value) stored in this and the descendant nodes
+        """yield (key, value) stored in this and the descendant nodes
         :param node: node in form of list, or BLANK_NODE
 
         .. note::
             Here key is in full form, rather than key of the individual node
-        '''
+        """
         if node == BLANK_NODE:
             raise StopIteration
 
@@ -949,10 +949,10 @@ class Trie(object):
         return self.get(key) != BLANK_NODE
 
     def update(self, key, value):
-        '''
+        """
         :param key: a string
         :value: a string
-        '''
+        """
         if not is_string(key):
             raise Exception("Key must be string")
 

--- a/ethereum/tests/test_contracts.py
+++ b/ethereum/tests/test_contracts.py
@@ -12,10 +12,10 @@ from ethereum.utils import safe_ord, big_endian_to_int
 
 
 # Test EVM contracts
-serpent_code = '''
+serpent_code = """
 def main(a,b):
     return(a ^ b)
-'''
+"""
 
 
 def test_evm():
@@ -31,8 +31,7 @@ def test_evm():
 
 # Test serpent compilation of variables using _with_, doing a simple
 # arithmetic calculation 20 * 30 + 10 = 610
-sixten_code =\
-    '''
+sixten_code = """
 (with 'x 10
     (with 'y 20
         (with 'z 30
@@ -43,7 +42,7 @@ sixten_code =\
         )
     )
 )
-'''
+"""
 
 
 def test_sixten():
@@ -54,8 +53,7 @@ def test_sixten():
     assert utils.big_endian_to_int(o1) == 610
 
 
-with_code = \
-    """
+with_code = """
 def f1():
     o = array(4)
     with x = 5:
@@ -103,23 +101,21 @@ def test_with():
 
 # Test Serpent's import mechanism
 
-mul2_code = \
-    '''
+mul2_code = """
 def double(v):
     log(v)
     return(v*2)
-'''
+"""
 
 filename = "mul2_qwertyuioplkjhgfdsa.se"
 
-returnten_code = \
-    '''
+returnten_code = """
 extern mul2: [double:i]
 
 x = create("%s")
 log(x)
 return(x.double(5))
-''' % filename
+""" % filename
 
 
 def test_returnten():
@@ -133,25 +129,23 @@ def test_returnten():
 
 # Test inset
 
-inset_inner_code = \
-    '''
+inset_inner_code = """
 def g(n):
     return(n + 10)
 
 def f(n):
     return n*2
-'''
+"""
 
 filename2 = "inner_qwertyuioplkjhgfdsa.se"
 
-inset_outer_code = \
-    '''
+inset_outer_code = """
 inset("%s")
 
 def foo():
     res = self.g(12)
     return res
-''' % filename2
+""" % filename2
 
 
 def test_inset():
@@ -163,26 +157,23 @@ def test_inset():
 
 # Inset at the end instead
 
-inset_inner_code2 = \
-    '''
+inset_inner_code2 = """
 def g(n):
     return(n + 10)
 
 def f(n):
     return n*2
-'''
+"""
 
 filename25 = "inner_qwertyuioplkjhgfdsa.se"
 
-inset_outer_code2 = \
-    '''
-
+inset_outer_code2 = """
 def foo():
     res = self.g(12)
     return res
 
 inset("%s")
-''' % filename25
+""" % filename25
 
 
 def test_inset2():
@@ -195,15 +186,14 @@ def test_inset2():
 
 # Test a simple namecoin implementation
 
-namecoin_code =\
-    '''
+namecoin_code ="""
 def main(k, v):
     if !self.storage[k]:
         self.storage[k] = v
         return(1)
     else:
         return(0)
-'''
+"""
 
 
 def test_namecoin():
@@ -220,7 +210,7 @@ def test_namecoin():
 
 # Test a simple currency implementation
 
-currency_code = '''
+currency_code = """
 data balances[2^160]
 
 def init():
@@ -239,7 +229,7 @@ def send(to, value):
         return(1)
     else:
         return(0)
-'''
+"""
 
 
 def test_currency():
@@ -256,7 +246,7 @@ def test_currency():
 
 # Test a data feed
 
-data_feed_code = '''
+data_feed_code = """
 data creator
 data values[]
 
@@ -273,7 +263,7 @@ def set(k, v):
 
 def get(k):
     return(self.values[k])
-'''
+"""
 
 
 def test_data_feeds():
@@ -294,7 +284,7 @@ def test_data_feeds():
 # Test an example hedging contract, using the data feed. This tests
 # contracts calling other contracts
 
-hedge_code = '''
+hedge_code = """
 extern datafeed: [set:ii, get:i]
 
 data partyone
@@ -333,7 +323,7 @@ def main(datafeed, index):
             return(4)
         else:
             return(5)
-'''
+"""
 
 
 def test_hedge():
@@ -370,7 +360,7 @@ def test_hedge():
 
 
 # Test the LIFO nature of call
-arither_code = '''
+arither_code = """
 def init():
     self.storage[0] = 10
 
@@ -384,7 +374,7 @@ def f2():
 
 def f3():
     return(self.storage[0])
-'''
+"""
 
 
 def test_lifo():
@@ -395,7 +385,7 @@ def test_lifo():
 
 
 # Test suicides and suicide reverts
-suicider_code = '''
+suicider_code = """
 def mainloop(rounds):
     self.storage[15] = 40
     self.suicide()
@@ -416,7 +406,7 @@ def suicide():
 
 def ping_storage15():
     return(self.storage[15])
-'''
+"""
 
 
 def test_suicider():
@@ -442,7 +432,7 @@ def test_suicider():
 
 # Test reverts
 
-reverter_code = '''
+reverter_code = """
 def entry():
     self.non_recurse(gas=100000)
     self.recurse(gas=100000)
@@ -459,7 +449,7 @@ def recurse():
     self.recurse()
     while msg.gas > 0:
         self.storage["waste_some_gas"] = 0
-'''
+"""
 
 
 def test_reverter():
@@ -473,16 +463,14 @@ def test_reverter():
 
 # Test stateless contracts
 
-add1_code = \
-    '''
+add1_code = """
 def main(x):
     self.storage[1] += x
-'''
+"""
 
 filename3 = "stateless_qwertyuioplkjhgfdsa.se"
 
-callcode_test_code = \
-    '''
+callcode_test_code = """
 extern add1: [main:i]
 
 x = create("%s")
@@ -491,7 +479,7 @@ x.main(4, call=code)
 x.main(60, call=code)
 x.main(40)
 return(self.storage[1])
-''' % filename3
+""" % filename3
 
 
 def test_callcode():
@@ -505,12 +493,12 @@ def test_callcode():
 
 
 # https://github.com/ethereum/serpent/issues/8
-array_code = '''
+array_code = """
 def main():
     a = array(1)
     a[0] = 1
     return(a, items=1)
-'''
+"""
 
 
 def test_array():
@@ -518,13 +506,13 @@ def test_array():
     x = c.contract(array_code, language='serpent')
     assert x.main() == [1]
 
-array_code2 = '''
+array_code2 = """
 def main():
     a = array(1)
     something = 2
     a[0] = 1
     return(a, items=1)
-'''
+"""
 
 
 def test_array2():
@@ -1057,8 +1045,7 @@ def test_sort():
 
 filename9 = "mul2_qwertyuioplkjhgfdsabarbar.se"
 
-sort_tester_code = \
-    '''
+sort_tester_code = """
 extern sorter: [sort:a]
 data sorter
 
@@ -1067,7 +1054,7 @@ def init():
 
 def test(args:arr):
     return(self.sorter.sort(args, outsz=len(args)):arr)
-''' % filename9
+""" % filename9
 
 
 @pytest.mark.timeout(100)

--- a/ethereum/tests/todo/test_serialization.py
+++ b/ethereum/tests/todo/test_serialization.py
@@ -3,21 +3,19 @@ from ethereum import tester, block
 import pytest
 
 
-mul2_code = \
-    '''
+mul2_code = """
 def double(v):
     return(v*2)
-'''
+"""
 
 filename = "mul2_qwertyuioplkjhgfdsa.se"
 
-returnten_code = \
-    '''
+returnten_code = """
 extern mul2: [double:i]
 
 x = create("%s")
 return(x.double(5))
-''' % filename
+""" % filename
 
 
 @pytest.mark.skip()

--- a/ethereum/tests/todo/test_solidity.py
+++ b/ethereum/tests/todo/test_solidity.py
@@ -126,16 +126,15 @@ def test_symbols():
 
 @pytest.mark.skipif(not SOLIDITY_AVAILABLE, reason='solc compiler not available')
 def test_interop():
-    serpent_contract = """\
-extern solidity: [sub2:[]:i]
-
-def main(a):
-    return(a.sub2() * 2)
-
-def sub1():
-    return(5)
-
-"""
+    serpent_contract = """
+    extern solidity: [sub2:[]:i]
+    
+    def main(a):
+        return(a.sub2() * 2)
+    
+    def sub1():
+        return(5)
+    """
 
     solidity_contract = """
     contract serpent { function sub1() returns (int256 y) {} }
@@ -169,7 +168,7 @@ def sub1():
 
 @pytest.mark.skipif(not SOLIDITY_AVAILABLE, reason='solc compiler not available')
 def test_constructor():
-    constructor_contract = '''
+    constructor_contract = """
     contract testme {
         uint value;
         function testme(uint a) {
@@ -179,7 +178,7 @@ def test_constructor():
             return value;
         }
     }
-    '''
+    """
 
     state = tester.state()
     contract = state.abi_contract(

--- a/ethereum/trie.py
+++ b/ethereum/trie.py
@@ -112,9 +112,9 @@ def unpack_to_nibbles(bindata):
 
 
 def starts_with(full, part):
-    ''' test whether the items in the part is
+    """ test whether the items in the part is
     the leading items of the full
-    '''
+    """
     if len(full) < len(part):
         return False
     return full[:len(part)] == part
@@ -140,20 +140,20 @@ BLANK_ROOT = utils.sha3rlp(b'')
 class Trie(object):
 
     def __init__(self, db, root_hash=BLANK_ROOT):
-        '''it also present a dictionary like interface
+        """it also present a dictionary like interface
 
         :param db key value database
         :root: blank or trie node in form of [key, value] or [v0,v1..v15,v]
-        '''
+        """
         self.db = db  # Pass in a database object directly
         self.set_root_hash(root_hash)
 
     # def __init__(self, dbfile, root_hash=BLANK_ROOT):
-    #     '''it also present a dictionary like interface
+    #     """it also present a dictionary like interface
 
     #     :param dbfile: key value database
     #     :root: blank or trie node in form of [key, value] or [v0,v1..v15,v]
-    #     '''
+    #     """
     #     if isinstance(dbfile, str):
     #         dbfile = os.path.abspath(dbfile)
     #         self.db = DB(dbfile)
@@ -163,8 +163,8 @@ class Trie(object):
 
     @property
     def root_hash(self):
-        '''always empty or a 32 bytes string
-        '''
+        """always empty or a 32 bytes string
+        """
         return self._root_hash
 
     def get_root_hash(self):
@@ -191,8 +191,8 @@ class Trie(object):
         self._root_hash = root_hash
 
     def clear(self):
-        ''' clear all tree data
-        '''
+        """ clear all tree data
+        """
         self._delete_child_storage(self.root_node)
         self._delete_node_storage(self.root_node)
         self.root_node = BLANK_NODE
@@ -227,11 +227,11 @@ class Trie(object):
         return o
 
     def _get_node_type(self, node):
-        ''' get node type and content
+        """ get node type and content
 
         :param node: node in form of list, or BLANK_NODE
         :return: node type
-        '''
+        """
         if node == BLANK_NODE:
             return NODE_TYPE_BLANK
 
@@ -592,9 +592,9 @@ class Trie(object):
         return nibbles_to_bin(without_terminator(o)) if o else None
 
     def _delete_node_storage(self, node):
-        '''delete storage
+        """delete storage
         :param node: node in form of list, or BLANK_NODE
-        '''
+        """
         if node == BLANK_NODE:
             return
         # assert isinstance(node, list)
@@ -631,8 +631,8 @@ class Trie(object):
             return self._delete_kv_node(node, key)
 
     def _normalize_branch_node(self, node):
-        '''node should have only one item changed
-        '''
+        """node should have only one item changed
+        """
         not_blank_items_count = sum(1 for x in range(17) if node[x])
         assert not_blank_items_count >= 1
 
@@ -729,9 +729,9 @@ class Trie(object):
         assert False
 
     def delete(self, key):
-        '''
+        """
         :param key: a string with length of [0, 32]
-        '''
+        """
         if not is_string(key):
             raise Exception("Key must be string")
 
@@ -744,10 +744,10 @@ class Trie(object):
         self._update_root_hash()
 
     def _get_size(self, node):
-        '''Get counts of (key, value) stored in this and the descendant nodes
+        """Get counts of (key, value) stored in this and the descendant nodes
 
         :param node: node in form of list, or BLANK_NODE
-        '''
+        """
         if node == BLANK_NODE:
             return 0
 
@@ -766,12 +766,12 @@ class Trie(object):
             return sum(sizes)
 
     def _iter_branch(self, node):
-        '''yield (key, value) stored in this and the descendant nodes
+        """yield (key, value) stored in this and the descendant nodes
         :param node: node in form of list, or BLANK_NODE
 
         .. note::
             Here key is in full form, rather than key of the individual node
-        '''
+        """
         if node == BLANK_NODE:
             raise StopIteration
 
@@ -809,7 +809,7 @@ class Trie(object):
             yield key, value
 
     def _to_dict(self, node):
-        '''convert (key, value) stored in this and the descendant nodes
+        """convert (key, value) stored in this and the descendant nodes
         to dict items.
 
         :param node: node in form of list, or BLANK_NODE
@@ -817,7 +817,7 @@ class Trie(object):
         .. note::
 
             Here key is in full form, rather than key of the individual node
-        '''
+        """
         if node == BLANK_NODE:
             return {}
 
@@ -885,10 +885,10 @@ class Trie(object):
         return self.get(key) != BLANK_NODE
 
     def update(self, key, value):
-        '''
+        """
         :param key: a string
         :value: a string
-        '''
+        """
         if not is_string(key):
             raise Exception("Key must be string")
 

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -356,21 +356,21 @@ def sha3rlp(x):
 
 
 def decode_bin(v):
-    '''decodes a bytearray from serialization'''
+    """decodes a bytearray from serialization"""
     if not is_string(v):
         raise Exception("Value must be binary, not RLP array")
     return v
 
 
 def decode_addr(v):
-    '''decodes an address from serialization'''
+    """decodes an address from serialization"""
     if len(v) not in [0, 20]:
         raise Exception("Serialized addresses must be empty or 20 bytes long!")
     return encode_hex(v)
 
 
 def decode_int(v):
-    '''decodes and integer from serialization'''
+    """decodes and integer from serialization"""
     if len(v) > 0 and (v[0] == b'\x00' or v[0] == 0):
         raise Exception("No leading zero bytes allowed for integers")
     return big_endian_to_int(v)
@@ -381,17 +381,17 @@ def decode_int256(v):
 
 
 def encode_bin(v):
-    '''encodes a bytearray into serialization'''
+    """encodes a bytearray into serialization"""
     return v
 
 
 def encode_root(v):
-    '''encodes a trie root into serialization'''
+    """encodes a trie root into serialization"""
     return v
 
 
 def encode_int(v):
-    '''encodes an integer into serialization'''
+    """encodes an integer into serialization"""
     if not is_numeric(v) or v < 0 or v >= TT256:
         raise Exception("Integer invalid or out of range: %r" % v)
     return int_to_big_endian(v)
@@ -468,7 +468,7 @@ def parse_as_int(s):
 
 
 def print_func_call(ignore_first_arg=False, max_call_number=100):
-    ''' utility function to facilitate debug, it will print input args before
+    """ utility function to facilitate debug, it will print input args before
     function call, and print return value after function call
 
     usage:
@@ -479,7 +479,7 @@ def print_func_call(ignore_first_arg=False, max_call_number=100):
 
     :param ignore_first_arg: whether print the first arg or not.
     useful when ignore the `self` parameter of an object method call
-    '''
+    """
     from functools import wraps
 
     def display(x):

--- a/tools/fixture_to_example.py
+++ b/tools/fixture_to_example.py
@@ -2,7 +2,7 @@
 
 
 def fixture_to_tables(fixture):
-    ''' convert fixture into *behave* examples
+    """ convert fixture into *behave* examples
     :param fixture: a dictionary in the following form::
 
         {
@@ -22,7 +22,7 @@ def fixture_to_tables(fixture):
 
     :return: a list, with each item represent a table: `(caption, rows)`,
     each item in `rows` is `(col1, col2,...)`
-    '''
+    """
 
     tables = []
     for (title, content) in fixture.iteritems():
@@ -44,9 +44,9 @@ def fixture_to_tables(fixture):
 
 
 def format_item(item, py=True):
-    '''
+    """
     :param py: python format or not
-    '''
+    """
     # for non python format, just output itself.
     # so the result is `something` instead of `"something"`
     if not py:
@@ -62,10 +62,10 @@ def format_item(item, py=True):
 
 
 def format_to_example(table, tabspace=2, indent=2):
-    ''' format table to *behave* example
+    """ format table to *behave* example
     :param table: `(caption, rows)`, each item in `rows` is `(col1, col2,...)`
     :return
-    '''
+    """
     from io import StringIO
     output = StringIO()
 


### PR DESCRIPTION
- Updated docstrings using Triple-single-quotes to Triple-double-quotes according to [PEP 257 -- Docstring Conventions](https://www.python.org/dev/peps/pep-0257/)
- Updated to use Triple-double-quotes when assign contract codes