### PR TITLE
New Makefile rule to run just a minimal set of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,11 @@ install:
   - travis_retry pip install tox
   - travis_retry pip install coverage
   - travis_retry pip install flake8
+  - travis_retry python setup.py install
+  - travis_retry pip install -r dev_requirements.txt
 script:
-  make lint-minimal
+  - make lint-minimal
+  - make test-minimal
   # XXX: For now we're only performing minimal CI checks as most tests are
   # broken. Tests will be individually added here as they're fixed.
   #- if [ -d .tox/$TOX_ENV/ ]; then cd .tox/$TOX_ENV && coverage erase; fi;

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ lint-minimal:
 test:
 	py.test --tb=no ethereum/tests/
 
+test-minimal:
+	py.test ethereum/tests/test_abi.py ethereum/tests/test_bloom.py ethereum/tests/test_chain.py ethereum/tests/test_compress.py ethereum/tests/test_db.py ethereum/tests/test_difficulty.py ethereum/tests/test_opcodes.py ethereum/tests/test_trie_next_prev.py ethereum/tests/test_utils.py
+
 testnovm:
 	py.test --tb=no ethereum/tests/ --ignore=ethereum/tests/test_vm.py
 


### PR DESCRIPTION
The idea is to run just the tests that are currently passing, and add
new ones as they're fixed.