### PR TITLE
Added py-ecc (ethereum/py_pairing) to dev_requirements.txt

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,4 +3,5 @@ coveralls
 pytest>=2.9.0
 pytest-catchlog==1.2.2
 pytest-timeout==1.0.0
+py-ecc
 https://github.com/ethereum/serpent/tarball/develop


### PR DESCRIPTION
Hi, this is something we stumbled upon when trying to run the testsuite from within ``pyethereum`` to compare the stack traces with ``ethereumjs`` results. Thought I make a short pull request.