### PR TITLE
fix #764, add py_ecc(py_pairing) dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ PyYAML
 repoze.lru
 pbkdf2
 scrypt
-py_ecc
+https://github.com/ethereum/py_pairing/tarball/master
 rlp>=0.4.7
 https://github.com/ethereum/ethash/tarball/master

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open('README.rst') as readme_file:
 install_requires = set(x.strip() for x in open('requirements.txt'))
 install_requires_replacements = {
     'https://github.com/ethereum/ethash/tarball/master': 'pyethash',
+    'https://github.com/ethereum/py_pairing/tarball/master': 'py_ecc'
 }
 install_requires = [install_requires_replacements.get(r, r) for r in install_requires]
 


### PR DESCRIPTION
The py_ecc on pypi is broken, resulting `pip install -r requirements.txt` fails.
In this PR, py_ecc is replaced with  py_pairing github repo 