### PR TITLE
added a command line option to print vm trace

### DIFF
--- a/ethereum/tests/conftest.py
+++ b/ethereum/tests/conftest.py
@@ -17,3 +17,13 @@ def pytest_runtest_call(item):
 
     if catchlog_handler and catchlog_handler in slogging.rootLogger.handlers:
         slogging.rootLogger.removeHandler(catchlog_handler)
+
+
+# Configuration file for adding commandline arguements in pytest
+def pytest_addoption(parser):
+    parser.addoption("--tracevm", action="store_true",
+        help="print vm trace")
+
+@pytest.fixture
+def tracevm(request):
+    return request.config.getoption("--tracevm")

--- a/ethereum/tests/test_state.py
+++ b/ethereum/tests/test_state.py
@@ -6,9 +6,9 @@ from ethereum.slogging import get_logger, configure_logging
 logger = get_logger()
 # customize VM log output to your needs
 # hint: use 'py.test' with the '-s' option to dump logs to the console
-if '--trace' in sys.argv:  # not default
+if '--tracevm' in sys.argv:  # not default
     configure_logging(':trace')
-    sys.argv.remove('--trace')
+    sys.argv.remove('--tracevm')
 
 
 def test_state(filename, testname, testdata):


### PR DESCRIPTION
Added a command line option --tracevm to print out the vm trace when testing. 

`usage: pytest -s <file-name> --tracevm`