### PR TITLE
Update tester, slogging, & transactions

### DIFF
--- a/ethereum/slogging.py
+++ b/ethereum/slogging.py
@@ -312,12 +312,16 @@ def configure(config_string=None, log_json=False, log_file=None):
         if hasattr(logger, 'setLevel'):
             # Guard against `logging.PlaceHolder` instances
             logger.setLevel(logging.NOTSET)
-            logger.propagate = True
+            if config_string == ":{}".format(DEFAULT_LOGLEVEL):
+                logger.propagate = True
+            else:
+                logger.propagate = False
 
     for name_levels in config_string.split(','):
         name, _, level = name_levels.partition(':')
         logger = getLogger(name)
         logger.setLevel(level.upper())
+        logger.propagate = True
 
 configure_logging = configure
 

--- a/ethereum/tests/test_tester.py
+++ b/ethereum/tests/test_tester.py
@@ -34,7 +34,7 @@ def test_abicontract_interface():
     abi_json = json.dumps(simple_data['abi']).encode('utf-8')
 
     abi = ABIContract(
-        _chain=tester_state,
+        _tester=tester_state,
         _abi=abi_json,
         address=simple_address,
     )

--- a/ethereum/tools/tester.py
+++ b/ethereum/tools/tester.py
@@ -1,6 +1,6 @@
 from ethereum.utils import sha3, privtoaddr, int_to_addr, to_string, big_endian_to_int, checksum_encode, int_to_big_endian, encode_hex
 from ethereum.genesis_helpers import mk_basic_state
-from ethereum.pow import chain
+from ethereum.pow import chain as pow_chain
 from ethereum.transactions import Transaction
 from ethereum.consensus_strategy import get_consensus_strategy
 from ethereum.config import config_homestead, config_tangerine, config_spurious, config_metropolis, default_config, Env
@@ -63,9 +63,10 @@ from ethereum.slogging import configure_logging
 config_string = ':info'
 # configure_logging(config_string=config_string)
 
+
 class ABIContract(object):  # pylint: disable=too-few-public-methods
 
-    def __init__(self, _chain, _abi, address):
+    def __init__(self, _tester, _abi, address):
         self.address = address
 
         if isinstance(_abi, ContractTranslator):
@@ -76,12 +77,15 @@ class ABIContract(object):  # pylint: disable=too-few-public-methods
         self.translator = abi_translator
 
         for function_name in self.translator.function_data:
-            function = self.method_factory(_chain, function_name)
+            if self.translator.function_data[function_name]['is_constant']:
+                function = self.method_factory(_tester.call, function_name)
+            else:
+                function = self.method_factory(_tester.tx, function_name)
             method = types.MethodType(function, self)
             setattr(self, function_name, method)
 
     @staticmethod
-    def method_factory(test_chain, function_name):
+    def method_factory(tx_or_call, function_name):
         """ Return a proxy for calling a contract method with automatic encoding of
         argument and decoding of results.
         """
@@ -89,12 +93,13 @@ class ABIContract(object):  # pylint: disable=too-few-public-methods
         def kall(self, *args, **kwargs):
             key = kwargs.get('sender', k0)
 
-            result = test_chain.tx(  # pylint: disable=protected-access
+            result = tx_or_call(  # pylint: disable=protected-access
                 sender=key,
                 to=self.address,
                 value=kwargs.get('value', 0),
                 data=self.translator.encode(function_name, args),
-                startgas=kwargs.get('startgas', STARTGAS)
+                startgas=kwargs.get('startgas', STARTGAS),
+                gasprice=kwargs.get('gasprice', GASPRICE)
             )
 
             if result is False:
@@ -117,14 +122,36 @@ def get_env(env):
     return env if isinstance(env, Env) else Env(config=d[env])
 
 
+class State(object):
+    def __init__(self, genesis):
+        self.state = genesis
+
+    def tx(self, sender=k0, to=b'\x00' * 20, value=0, data=b'', startgas=STARTGAS, gasprice=GASPRICE):
+        sender_addr = privtoaddr(sender)
+        transaction = Transaction(self.state.get_nonce(sender_addr), gasprice, startgas,
+                                  to, value, data).sign(sender)
+        success, output = apply_transaction(self.state, transaction)
+        if not success:
+            raise TransactionFailed()
+        return output
+
+    def call(self, sender=k0, to=b'\x00' * 20, value=0, data=b'', startgas=STARTGAS, gasprice=GASPRICE):
+        state = self.state
+        self.state = self.state.ephemeral_clone()
+        try:
+            output = self.tx(sender, to, value, data, startgas, gasprice)
+            self.state = state
+            return output
+        except Exception as e:
+            self.state = state
+            raise e
+
 class Chain(object):
-    def __init__(self, alloc=None, env=None):
-        self.chain = chain.Chain(
-            genesis=mk_basic_state(base_alloc if alloc is None else alloc,
-                                   None,
-                                   get_env(env)),
-            reset_genesis=True
-        )
+    def __init__(self, alloc=base_alloc, env=None, genesis=None):
+        if genesis:
+            self.chain = pow_chain.Chain(genesis, reset_genesis=True)
+        else:
+            self.chain = pow_chain.Chain(mk_basic_state(alloc, None, get_env(env)), reset_genesis=True)
         self.cs = get_consensus_strategy(self.chain.env.config)
         self.block = mk_block_from_prevstate(self.chain, timestamp=self.chain.state.timestamp + 1)
         self.head_state = self.chain.state.ephemeral_clone()
@@ -144,9 +171,19 @@ class Chain(object):
         sender_addr = privtoaddr(sender)
         transaction = Transaction(self.head_state.get_nonce(sender_addr), gasprice, startgas,
                                   to, value, data).sign(sender)
-        o = self.direct_tx(transaction)
+        output = self.direct_tx(transaction)
         self.last_sender = sender
-        return o
+        return output
+
+    def call(self, sender=k0, to=b'\x00' * 20, value=0, data=b'', startgas=STARTGAS, gasprice=GASPRICE):
+        snapshot = self.snapshot()
+        try:
+            output = self.tx(sender, to, value, data, startgas, gasprice)
+            self.revert(snapshot)
+            return output
+        except Exception as e:
+            self.revert(snapshot)
+            raise e
 
     def contract(self, sourcecode, args=[], sender=k0, value=0, language='evm', startgas=STARTGAS, gasprice=GASPRICE):
         if language == 'evm':
@@ -165,13 +202,17 @@ class Chain(object):
         set_execution_results(self.head_state, self.block)
         self.block = Miner(self.block).mine(rounds=100, start_nonce=0)
         assert self.chain.add_block(self.block)
-        assert self.head_state.trie.root_hash == self.chain.state.trie.root_hash
+        b = self.block
         for i in range(1, number_of_blocks):
-            b, _ = make_head_candidate(self.chain, timestamp=self.chain.state.timestamp + 14)
+            b, _ = make_head_candidate(self.chain, parent=b, timestamp=self.chain.state.timestamp + 14, coinbase=coinbase)
             b = Miner(b).mine(rounds=100, start_nonce=0)
             assert self.chain.add_block(b)
-        self.block = mk_block_from_prevstate(self.chain, timestamp=self.chain.state.timestamp + 14)
-        self.head_state = self.chain.state.ephemeral_clone()
+        self.change_head(b.header.hash, coinbase)
+        return b
+
+    def change_head(self, parent, coinbase=a0):
+        self.head_state = self.chain.mk_poststate_of_blockhash(parent).ephemeral_clone()
+        self.block = mk_block_from_prevstate(self.chain, self.head_state, timestamp=self.chain.state.timestamp, coinbase=coinbase)
         self.cs.initialize(self.head_state, self.block)
 
     def snapshot(self):
@@ -190,7 +231,7 @@ def int_to_0x_hex(v):
         return '0x' + o[1:]
     else:
         return '0x' + o
-    
+
 
 def mk_state_test_prefill(c):
     env = {

--- a/ethereum/transactions.py
+++ b/ethereum/transactions.py
@@ -155,6 +155,9 @@ class Transaction(rlp.Serializable):
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.hash == other.hash
 
+    def __lt__(self, other):
+        return isinstance(other, self.__class__) and self.hash < other.hash
+
     def __hash__(self):
         return utils.big_endian_to_int(self.hash)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scrypt
 py_ecc
 rlp>=0.4.7
 https://github.com/ethereum/ethash/tarball/master
+pycryptodome==3.4.6


### PR DESCRIPTION
This PR includes changes which I made while developing Casper, which are not core to Casper itself but instead changes to `pyethereum` more generally.

# Changes
### tester.py
- Add `change_head` which allows you to pick a new head to build on within your chain. This is super useful for testing forking logic
- Add `State`: This class is a simplified version of `Chain` which doesn't have any block logic.
- Add `call`: Tester will now detect that a transaction can be a call and should therefore not be actually submitted to the block and instead just allow the value to be returned.

### slogging.py
Set `logger.propagate` to False, unless explicitly specified in the config string. If no config string is given, then we use the defaults.

I made this change because I felt like the config string might have been broken, and this seemed to produce the correct behavior. Definitely open to comments from anyone who has really looked into the slogging code.

### transactions.py
This change was motivated by a bug I had early on when processing multiple transactions in a block, I believe.

### requirements.txt
Pycryptodome was missing from the requirements. `ModuleNotFoundError: No module named 'Crypto'`