### PR TITLE
add pycryptodome to requirements.txt again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scrypt
 py_ecc
 rlp>=0.4.7
 https://github.com/ethereum/ethash/tarball/master
+pycryptodome==3.4.6


### PR DESCRIPTION
pycryptodome was in at https://github.com/ethereum/pyethereum/commit/66d88fe8069490e7ec53c1acf157ed0ba5ce83c0
 but was regressed in https://github.com/ethereum/pyethereum/commit/85efc8688a3adb45cf9e74fa17022ca4df3ad16a
