### PR TITLE
Metropolis/Byzantium test fixes

### DIFF
--- a/ethereum/opcodes.py
+++ b/ethereum/opcodes.py
@@ -38,6 +38,8 @@ opcodes = {
     0x3a: ['GASPRICE', 0, 1, 2],
     0x3b: ['EXTCODESIZE', 1, 1, 20], # now 700
     0x3c: ['EXTCODECOPY', 4, 0, 20], # now 700
+    0x3d: ['RETURNDATASIZE', 0, 1, 2],
+    0x3e: ['RETURNDATACOPY', 3, 0, 3],
     0x40: ['BLOCKHASH', 1, 1, 20],
     0x41: ['COINBASE', 0, 1, 2],
     0x42: ['TIMESTAMP', 0, 1, 2],

--- a/ethereum/opcodes.py
+++ b/ethereum/opcodes.py
@@ -77,6 +77,8 @@ opcodes = {
     0xff: ['SUICIDE', 1, 0, 0], # 5000 now
 }
 
+opcodesMetropolis = { 0x3d, 0x3e, 0xfa, 0xfd }
+
 for i in range(1, 33):
     opcodes[0x5f + i] = ['PUSH' + str(i), 0, 1, 3]
 

--- a/ethereum/specials.py
+++ b/ethereum/specials.py
@@ -192,7 +192,7 @@ def proc_ecpairing(ext, msg):
             p2 = zero
         if bn128.multiply(p2, bn128.curve_order)[-1] != bn128.FQ2.zero():
             return 0, 0, []
-        exponent *= py_pairing.pairing(p2, p1, final_exponentiate=False)
+        exponent *= bn128.pairing(p2, p1)
     result = bn128.final_exponentiate(exponent) == bn128.FQ12.one()
     return 1, msg.gas - gascost, [0] * 31 + [1 if result else 0]
 

--- a/ethereum/tools/new_statetest_utils.py
+++ b/ethereum/tools/new_statetest_utils.py
@@ -41,7 +41,7 @@ configs = {
     #"Homestead": config_homestead,
     #"EIP150": config_tangerine,
     "EIP158": config_spurious,
-    "Metropolis": config_metropolis
+    "Byzantium": config_metropolis
 }
 
 # Makes a diff between a prev and post state

--- a/ethereum/vm.py
+++ b/ethereum/vm.py
@@ -565,11 +565,12 @@ def vm_execute(ext, msg, code):
                 if ext.post_anti_dos_hardfork():
                     ingas = all_but_1n(ingas, opcodes.CALL_CHILD_LIMIT_DENOM)
                 create_msg = Message(msg.to, b'', value, ingas, cd, msg.depth + 1)
-                o, gas, addr = ext.create(create_msg)
+                o, gas, data = ext.create(create_msg)
                 if o:
-                    stk.append(utils.coerce_to_int(addr))
+                    stk.append(utils.coerce_to_int(data))
                 else:
                     stk.append(0)
+                    compustate.last_returned = bytearray(data)
                 compustate.gas = compustate.gas - ingas + gas
             else:
                 stk.append(0)

--- a/ethereum/vm.py
+++ b/ethereum/vm.py
@@ -210,6 +210,9 @@ def vm_execute(ext, msg, code):
         if opcode not in opcodes.opcodes:
             return vm_exception('INVALID OP', opcode=opcode)
 
+        if opcode in opcodes.opcodesMetropolis and not ext.post_metropolis_hardfork():
+            return vm_exception('INVALID OP (not yet enabled)', opcode=opcode)
+
         op, in_args, out_args, fee = opcodes.opcodes[opcode]
 
         # out of gas error


### PR DESCRIPTION
Update the test runner for the Metropolis to Byzantium rename (https://github.com/ethereum/tests/pull/241). The fixtures submodule was already updated to the renamed test files (https://github.com/ethereum/pyethereum/commit/85efc8688a3adb45cf9e74fa17022ca4df3ad16a), but the ~Metropolis~Byzantium tests were not running because the name was not updated in `new_statetest_utils.py`.

Add lines to opcodes.py for RETURNDATASIZE and RETURNDATACOPY (now the stReturnDataTest tests pass).

Fix the pairing dependency in specials.py (now the stZeroKnowledge tests pass).



