### PR TITLE
Add a check in tester.direct_tx

### DIFF
--- a/ethereum/tools/tester.py
+++ b/ethereum/tools/tester.py
@@ -157,7 +157,7 @@ class Chain(object):
 
     def direct_tx(self, transaction):
         self.last_tx = transaction
-        if privtoaddr(self.last_sender) != transaction.sender:
+        if self.last_sender is not None and privtoaddr(self.last_sender) != transaction.sender:
             self.last_sender = None
         success, output = apply_transaction(self.head_state, transaction)
         self.block.transactions.append(transaction)


### PR DESCRIPTION
To prevent from the error when `self.last_sender` is `None` already.
The following lines are the error messages:
```bash
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../.pyenv/versions/py3.6.0eth/lib/python3.6/site-packages/ethereum-2.0.4-py3.6.egg/ethereum/tools/tester.py:160: in direct_tx
    if privtoaddr(self.last_sender) != transaction.sender:
../../../.pyenv/versions/py3.6.0eth/lib/python3.6/site-packages/ethereum-2.0.4-py3.6.egg/ethereum/utils.py:188: in privtoaddr
    k = normalize_key(k)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ $

key = None

    def normalize_key(key):
        if is_numeric(key):
            o = encode_int32(key)
>       elif len(key) == 32:
E       TypeError: object of type 'NoneType' has no len()

../../../.pyenv/versions/py3.6.0eth/lib/python3.6/site-packages/ethereum-2.0.4-py3.6.egg/ethereum/utils.py:226: TypeError
```