### PR TITLE
solidity_names() recognizes interface

### DIFF
--- a/ethereum/tools/_solidity.py
+++ b/ethereum/tools/_solidity.py
@@ -165,6 +165,13 @@ def solidity_names(code):  # pylint: disable=too-many-branches
                 if result:
                     names.append(('contract', result.groups()[0]))
 
+            if char == 'i' and code[pos: pos + 9] == 'interface':
+                result = re.match('^interface[^_$a-zA-Z]+([_$a-zA-Z][_$a-zA-Z0-9]*)', code[pos:])
+
+                if result:
+                    names.append(('contract', result.groups()[0]))
+
+
             if char == 'l' and code[pos: pos + 7] == 'library':
                 result = re.match('^library[^_$a-zA-Z]+([_$a-zA-Z][_$a-zA-Z0-9]*)', code[pos:])
 


### PR DESCRIPTION
Rebased https://github.com/ethereum/pyethereum/pull/737 on top of latest develop. Did not alter the old PR since it's used by raiden as a pinned version and don't want to have to deal with the newest pyethereum develop in raiden at the moment.