### PR TITLE
update supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
Our new secp256k1 dep https://github.com/ofek/coincurve supports 2.7 and 3.5+. We also afaik run fine on 3.6 now.

The Python 3.4 download count for the last 30 days was only 165. That is far, far below our downloads for 2.7, 3.5, or 3.6.

I queried https://bigquery.cloud.google.com/dataset/the-psf:pypi using:

```
SELECT                                                                   
  REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)") as python_version,
  COUNT(*) as download_count,                                            
FROM                                                                     
  TABLE_DATE_RANGE(                                                      
    [the-psf:pypi.downloads],                                            
    DATE_ADD(CURRENT_TIMESTAMP(), -31, "day"),                           
    DATE_ADD(CURRENT_TIMESTAMP(), -1, "day")                             
  )                                                                      
WHERE                                                                    
  file.project = "ethereum"                                              
GROUP BY                                                                 
  python_version,                                                        
ORDER BY                                                                 
  download_count DESC                                                    
LIMIT 20                                                                 
```