### PR TITLE
fix for pre-metro (spurious dragon)

### DIFF
--- a/ethereum/opcodes.py
+++ b/ethereum/opcodes.py
@@ -78,6 +78,8 @@ opcodes = {
     0xff: ['SUICIDE', 1, 0, 0],  # 5000 now
 }
 
+opcodesMetropolis = { 0x3d, 0x3e, 0xfa, 0xfd }
+
 for i in range(1, 33):
     opcodes[0x5f + i] = ['PUSH' + str(i), 0, 1, 3]
 

--- a/ethereum/vm.py
+++ b/ethereum/vm.py
@@ -213,6 +213,9 @@ def vm_execute(ext, msg, code):
         if opcode not in opcodes.opcodes:
             return vm_exception('INVALID OP', opcode=opcode)
 
+        if opcode in opcodes.opcodesMetropolis and not ext.post_metropolis_hardfork():
+            return vm_exception('INVALID OP (not yet enabled)', opcode=opcode)
+
         op, in_args, out_args, fee = opcodes.opcodes[opcode]
 
         # Apply operation


### PR DESCRIPTION
Fix state tests under a pre-metro configuration (e.g. spurious dragon), as they currently fail.