### PR TITLE
Fix py3 support

### DIFF
--- a/ethereum/tools/keys.py
+++ b/ethereum/tools/keys.py
@@ -136,7 +136,10 @@ def make_keystore_json(priv, pw, kdf="pbkdf2", cipher="aes-128-ctr"):
     # Compute the MAC
     mac = sha3(derivedkey[16:32] + c)
     # Make a UUID
-    u = encode_hex(os.urandom(16))
+    if sys.version_info.major == 2:
+        u = encode_hex(os.urandom(16))
+    else:
+        u = os.urandom(16)
     uuid = b'-'.join((u[:8], u[8:12], u[12:16], u[16:20], u[20:]))
     # Return the keystore json
     return {

--- a/ethereum/tools/keys.py
+++ b/ethereum/tools/keys.py
@@ -137,9 +137,9 @@ def make_keystore_json(priv, pw, kdf="pbkdf2", cipher="aes-128-ctr"):
     mac = sha3(derivedkey[16:32] + c)
     # Make a UUID
     u = encode_hex(os.urandom(16))
-    uuid = b'-'.join((u[:8], u[8:12], u[12:16], u[16:20], u[20:]))
     if sys.version_info.major == 3:
-        uuid = encode_hex(uuid)
+        u = bytes(u, 'utf-8')
+    uuid = b'-'.join((u[:8], u[8:12], u[12:16], u[16:20], u[20:]))
     # Return the keystore json
     return {
         "crypto": {

--- a/ethereum/tools/keys.py
+++ b/ethereum/tools/keys.py
@@ -136,10 +136,9 @@ def make_keystore_json(priv, pw, kdf="pbkdf2", cipher="aes-128-ctr"):
     # Compute the MAC
     mac = sha3(derivedkey[16:32] + c)
     # Make a UUID
-    if sys.version_info.major == 2:
-        u = encode_hex(os.urandom(16))
-    else:
-        u = os.urandom(16)
+    u = encode_hex(os.urandom(16))
+    if sys.version_info.major == 3:
+        u = bytes(u, 'utf-8')
     uuid = b'-'.join((u[:8], u[8:12], u[12:16], u[16:20], u[20:]))
     # Return the keystore json
     return {

--- a/ethereum/tools/keys.py
+++ b/ethereum/tools/keys.py
@@ -137,9 +137,9 @@ def make_keystore_json(priv, pw, kdf="pbkdf2", cipher="aes-128-ctr"):
     mac = sha3(derivedkey[16:32] + c)
     # Make a UUID
     u = encode_hex(os.urandom(16))
-    if sys.version_info.major == 3:
-        u = bytes(u, 'utf-8')
     uuid = b'-'.join((u[:8], u[8:12], u[12:16], u[16:20], u[20:]))
+    if sys.version_info.major == 3:
+        uuid = encode_hex(uuid)
     # Return the keystore json
     return {
         "crypto": {


### PR DESCRIPTION
When running with `Python 3.5.2` the `make_keystore_json()` throws `TypeError`:
```python
from ethereum.tools import keys
test = keys.make_keystore_json(keys.sha3(b'private'), 'testing')

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pablo/.virtualenvs/rcn-exchange/lib/python3.5/site-packages/ethereum/tools/keys.py", line 143, in make_keystore_json
    uuid = b'-'.join((u[:8], u[8:12], u[12:16], u[16:20], u[20:]))
TypeError: sequence item 0: expected a bytes-like object, str found
```

Thanks! :rocket: 
