### PR TITLE
Fixed using "prev_headers" in genesis and a python 3 encoding bug

### DIFF
--- a/ethereum/block.py
+++ b/ethereum/block.py
@@ -199,3 +199,13 @@ class FakeHeader():
         self.gas_limit = gas_limit
         self.gas_used = gas_used
         self.uncles_hash = uncles_hash
+
+    def to_block_header(self):
+        return BlockHeader(
+            difficulty=self.difficulty,
+            number=self.number,
+            timestamp=self.timestamp,
+            gas_used=self.gas_used,
+            gas_limit=self.gas_limit,
+            uncles_hash=self.uncles_hash
+        )

--- a/ethereum/pow/chain.py
+++ b/ethereum/pow/chain.py
@@ -399,7 +399,7 @@ class Chain(object):
         self.db.put('head_hash', self.head_hash)
         self.db.put(block.hash, rlp.encode(block))
         self.db.put(b'changed:' + block.hash,
-                    b''.join([k.encode() if not isinstance(k, str) else k for k in list(changed.keys())]))
+                    b''.join([k.encode() if not isinstance(k, bytes) else k for k in list(changed.keys())]))
         print('Saved %d address change logs' % len(changed.keys()))
         self.db.put(b'deletes:' + block.hash, b''.join(deletes))
         log.debug('Saved %d trie node deletes for block %d (%s)' %

--- a/ethereum/state.py
+++ b/ethereum/state.py
@@ -370,7 +370,10 @@ class State():
                 else:
                     self.trie.delete(addr)
                     if self.executing_on_head:
-                        self.db.delete(b'address:' + addr)
+                        try:
+                            self.db.delete(b'address:' + addr)
+                        except KeyError:
+                            pass
         self.deletes.extend(self.trie.deletes)
         self.trie.deletes = []
         self.cache = {}
@@ -458,7 +461,9 @@ class State():
                 if 'storage' in data:
                     for k, v in data['storage'].items():
                         state.set_storage_data(
-                            addr, parse_as_bin(k), parse_as_bin(v))
+                            addr,
+                            big_endian_to_int(parse_as_bin(k)),
+                            big_endian_to_int(parse_as_bin(v)))
         elif "state_root" in snapshot_data:
             state.trie.root_hash = parse_as_bin(snapshot_data["state_root"])
         else:

--- a/ethereum/tests/test_chain.py
+++ b/ethereum/tests/test_chain.py
@@ -13,6 +13,7 @@ from ethereum.tests.utils import new_db
 from ethereum.state import State
 from ethereum.block import Block
 from ethereum.consensus_strategy import get_consensus_strategy
+from ethereum.genesis_helpers import mk_basic_state
 
 from ethereum.slogging import get_logger
 logger = get_logger()
@@ -353,6 +354,24 @@ def test_reward_uncles(db):
         chain.env.config['NEPHEW_REWARD']
     assert chain.state.get_balance(
         uncle_coinbase) == chain.env.config['BLOCK_REWARD'] * 7 // 8
+
+
+def test_genesis_from_state_snapshot():
+    """
+    Test if Chain could be initilaized from State snapshot
+    """
+    # Customize a state
+    k, v, k2, v2 = accounts()
+    alloc = {v: {"balance": utils.denoms.ether * 1}}
+    state = mk_basic_state(alloc, None)
+    state.block_difficulty = 1
+
+    # Initialize another chain from state.to_snapshot()
+    genesis = state.to_snapshot()
+    new_chain = Chain(genesis=genesis)
+    assert new_chain.state.trie.root_hash == state.trie.root_hash
+    assert new_chain.state.block_difficulty == state.block_difficulty
+    assert new_chain.head.number == state.block_number
 
 
 # TODO ##########################################

--- a/ethereum/todo_tests/test_pos.py
+++ b/ethereum/todo_tests/test_pos.py
@@ -207,10 +207,10 @@ t4 = Transaction(
 apply_transaction(chains[0].state, t4)
 post_bal = chains[0].state.get_balance(addrs[0])
 print('Wei withdrawn:', post_bal - pre_bal)
-blocks_by_v0_in_stage1 = len([x for x in vids[:200] if x == 0])
+blocks_by_v0_in_stage1 = len([i for i in vids[:200] if i == 0])
 expected_revenue_in_stage1 = blocks_by_v0_in_stage1 * \
     max(sum(deposit_sizes[:-1]), 1000000) * 10**18 * BLOCK_MAKING_PPB / 10**9
-blocks_by_v0_in_stage2 = len([x for x in vids[200:400] if x == 0])
+blocks_by_v0_in_stage2 = len([i for i in vids[200:400] if i == 0])
 expected_revenue_in_stage2 = blocks_by_v0_in_stage2 * \
     max(sum(deposit_sizes), 1000000) * 10**18 * BLOCK_MAKING_PPB / 10**9
 

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -114,7 +114,7 @@ def ecrecover_to_pub(rawhash, v, r, s):
 def ecsign(rawhash, key):
     if coincurve and hasattr(coincurve, 'PrivateKey') and False:
         pk = coincurve.PrivateKey(key)
-        signature = pk.sign_recoverable(msghash, hasher=None)
+        signature = pk.sign_recoverable(rawhash, hasher=None)
         v = safe_ord(signature[64]) + 27
         r = big_endian_to_int(signature[0:32])
         s = big_endian_to_int(signature[32:64])

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -96,8 +96,8 @@ def ecrecover_to_pub(rawhash, v, r, s):
     if coincurve and hasattr(coincurve, "PublicKey") and False:
         try:
             pk = coincurve.PublicKey.from_signature_and_message(
-                zpad(utils.bytearray_to_bytestr(int_to_32bytearray(r)), 32) + zpad(utils.bytearray_to_bytestr(int_to_32bytearray(s)), 32) +
-                utils.ascii_chr(v - 27),
+                zpad(bytearray_to_bytestr(int_to_32bytearray(r)), 32) + zpad(bytearray_to_bytestr(int_to_32bytearray(s)), 32) +
+                ascii_chr(v - 27),
                 rawhash,
                 hasher=None,
             )


### PR DESCRIPTION
### Description
1. Fixed the use case of initializing chain from `state.to_snapshot()` with `prev_headers`. It's mainly for testing and experiments. The use case would be like:

    ```python
    genesis = state.to_snapshot()
    chain = Chain(genesis=genesis)
    ```

2. In Python 3, `str` and `bytes` are different types. So I changed:
    ```python
    b''.join([k.encode() if not isinstance(k, str) else k for k in list(changed.keys())]))
    ```
    to
    ```python
    b''.join([k.encode() if not isinstance(k, bytes) else k for k in list(changed.keys())]))
    ```
3. Passed travis checks
   1. Fixed some pep8 `F821 undefined name` issues
   2. Fixed a wrong variable name in `utils.ecsign(rawhash, key)` function

### How to test
```sh
pytest ethereum/tests/test_chain.py::test_genesis_from_state_snapshot
``` 