### PR TITLE
Updated setup.py for passing CI and added Viper

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,4 +4,3 @@ pytest>=2.9.0
 pytest-catchlog==1.2.2
 pytest-timeout==1.0.0
 py-ecc
-https://github.com/ethereum/serpent/tarball/develop

--- a/ethereum/tools/tester.py
+++ b/ethereum/tools/tester.py
@@ -47,7 +47,7 @@ if _solidity:
 try:
     from viper import compiler
     languages['viper'] = compiler
-except ImportError:
+except (ImportError, TypeError):
     pass
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ https://github.com/ethereum/ethash/tarball/master
 pycryptodome==3.4.6
 coincurve>=5.0.1
 https://github.com/ethereum/serpent/tarball/develop
+https://github.com/ethereum/viper/tarball/master

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ with open('README.rst') as readme_file:
 install_requires = set(x.strip() for x in open('requirements.txt'))
 install_requires_replacements = {
     'https://github.com/ethereum/ethash/tarball/master': 'pyethash',
+    'https://github.com/ethereum/serpent/tarball/develop': 'ethereum-serpent',
+    'https://github.com/ethereum/viper/tarball/master': 'viper'
 }
 install_requires = [
     install_requires_replacements.get(
@@ -15,11 +17,12 @@ install_requires = [
 
 # dev requirements
 tests_require = set(x.strip() for x in open('dev_requirements.txt'))
-tests_require_replacements = dict()
-tests_require_replacements = {
-    'https://github.com/ethereum/serpent/tarball/develop': 'ethereum-serpent>=2.0.4'
-}
-tests_require = [tests_require_replacements.get(r, r) for r in tests_require]
+
+# dependency links
+dependency_links = []
+dependency_links.append('http://github.com/ethereum/serpent/tarball/develop#egg=ethereum-serpent-9.99.9')
+viper_ref = '12847483f571505cef72fcb725e6557db15bce29'  # 2017-09-12
+dependency_links.append('http://github.com/ethereum/viper/tarball/master/%s#egg=viper-9.99.9' % viper_ref)
 
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
 # see:
@@ -34,6 +37,7 @@ setup(
     url='https://github.com/ethereum/pyethereum/',
     install_requires=install_requires,
     tests_require=tests_require,
+    dependency_links=dependency_links,
     setup_requires=[
         #    'pytest-runner==2.7'
     ],


### PR DESCRIPTION
## Description
1. Fixed #800 
2. Using `install_requires` and `dependency_links` to get packages from GitHub.
3. Removed serpent from `dev_requirements.txt`
4. Because PR #791 (Casper integration) would need Viper, I add it in advance. And since Viper doesn’t have a released version and the development is rapid recently, I use a commit reference to lock specific version.
    * **Note that Viper requires Python 3.6+**
