### PR TITLE
Fixed implicit TypeError raised with ecrecover_to_pub with bad RS values

### DIFF
--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -105,8 +105,12 @@ def ecrecover_to_pub(rawhash, v, r, s):
         except BaseException:
             pub = b"\x00" * 64
     else:
-        x, y = ecdsa_raw_recover(rawhash, (v, r, s))
-        pub = encode_int32(x) + encode_int32(y)
+        result = ecdsa_raw_recover(rawhash, (v, r, s))
+        if result:
+            x, y = result
+            pub = encode_int32(x) + encode_int32(y)
+        else:
+            raise ValueError('Invalid VRS')
     assert len(pub) == 64
     return pub
 


### PR DESCRIPTION
Fixed utils.ecrecover_to_pub() to explicitly raise a ValueError instead of implicitly raise a TypeError on bad VRS input. Since ecdsa_raw_recover returns a single boolean of False in cases where RS don't assert, this usage caused a TypeError because you can't assign x, y to False. I would have had it return b"\x00" * 64 in this case to match the logic above except there were 12 tests which broke because they were expecting an error, so I have it just return a more correct error in this case so it's more obvious how this code works.