### PR TITLE
fixed ethereum 2.0.5 installation problem 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ rlp>=0.4.7
 https://github.com/ethereum/ethash/tarball/master
 pycryptodome==3.4.6
 coincurve>=5.0.1
-https://github.com/ethereum/serpent/tarball/develop
-https://github.com/ethereum/viper/tarball/master

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ with open('README.rst') as readme_file:
 install_requires = set(x.strip() for x in open('requirements.txt'))
 install_requires_replacements = {
     'https://github.com/ethereum/ethash/tarball/master': 'pyethash',
-    'https://github.com/ethereum/serpent/tarball/develop': 'ethereum-serpent',
-    'https://github.com/ethereum/viper/tarball/master': 'viper'
 }
 install_requires = [
     install_requires_replacements.get(
@@ -20,9 +18,6 @@ tests_require = set(x.strip() for x in open('dev_requirements.txt'))
 
 # dependency links
 dependency_links = []
-dependency_links.append('http://github.com/ethereum/serpent/tarball/develop#egg=ethereum-serpent-9.99.9')
-viper_ref = '12847483f571505cef72fcb725e6557db15bce29'  # 2017-09-12
-dependency_links.append('http://github.com/ethereum/viper/tarball/master/%s#egg=viper-9.99.9' % viper_ref)
 
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
 # see:


### PR DESCRIPTION
1. remove viper from setup.py
   - Could not find a version that satisfies the requirement viper #806 
2. remove serpent dependency (no longer supported)