### PR TITLE
Fixes bug in candidate block creation.

### DIFF
--- a/ethereum/common.py
+++ b/ethereum/common.py
@@ -71,7 +71,7 @@ def mk_block_from_prevstate(chain, state=None, timestamp=None,
     state = state or chain.state
     blk = Block(BlockHeader())
     now = timestamp or chain.time()
-    blk.header.number = state.block_number + 1
+    blk.header.number = state.prev_headers[0].number + 1
     blk.header.difficulty = calc_difficulty(
         state.prev_headers[0], now, chain.config)
     blk.header.gas_limit = calc_gaslimit(state.prev_headers[0], chain.config)


### PR DESCRIPTION
The previous code works only by happenstance.  When a new block is being created in the common path this function is used in, `state.prev_headers[0] == blk.header` because it isn't until a couple lines after this call that `blk.header = new_block_header`.  However, when instantiating a chain from a snapshot, this is not the case and `blk.header` is a candidate block, not the head block so its number is one higher.

Previously failing repro case:
```
from ethereum.tools.tester import Chain
from ethereum.config import config_metropolis, Env

def test_apple():
    chain = Chain(env=Env(config=config_metropolis))
    snapshot = chain.head_state.to_snapshot()
    chain = Chain(genesis=snapshot)
    chain.mine(1)
```
After `chain = Chain(genesis=snapshot)`, `chain.head_state.prev_headers[0].number == 1` and `chain.block.number == 3`, which results in a failure to mine the candidate block on the last line.