### PR TITLE
Fixes bug that prevented snapshots from being able to have a non-default environment.

### DIFF
--- a/ethereum/tools/tester.py
+++ b/ethereum/tools/tester.py
@@ -163,7 +163,7 @@ class Chain(object):
                 from ethereum.hybrid_casper import chain as hybrid_casper_chain
                 self.chain = hybrid_casper_chain.Chain(genesis, reset_genesis=True)
             else:
-                self.chain = pow_chain.Chain(genesis, reset_genesis=True)
+                self.chain = pow_chain.Chain(genesis, env=env, reset_genesis=True)
         else:
             self.chain = pow_chain.Chain(mk_basic_state(alloc, None, get_env(env)), reset_genesis=True)
         self.cs = get_consensus_strategy(self.chain.env.config)


### PR DESCRIPTION
When restoring a chain from a snapshot by passing a `state.to_snapshot()` into the Chain constructor, since the `env` isn't passed through this means the chain will use the default `env` with no mechanism for overriding it.

This change will allow the person instantiating the Chain from a snapshot to specify an `env` that they want to use and it will be passed along.