### PR TITLE
Python3 compatibility

### DIFF
--- a/ethereum/block.py
+++ b/ethereum/block.py
@@ -190,7 +190,7 @@ BLANK_UNCLES_HASH = sha3(rlp.encode([]))
 
 class FakeHeader():
 
-    def __init__(self, hash='\x00' * 32, number=0, timestamp=0, difficulty=1,
+    def __init__(self, hash=b'\x00' * 32, number=0, timestamp=0, difficulty=1,
                  gas_limit=3141592, gas_used=0, uncles_hash=BLANK_UNCLES_HASH):
         self.hash = hash
         self.number = number

--- a/ethereum/fast_rlp.py
+++ b/ethereum/fast_rlp.py
@@ -1,7 +1,12 @@
 import sys
 import rlp
-from .utils import int_to_big_endian, big_endian_to_int, safe_ord
-from . import db
+from ethereum.utils import ( 
+    int_to_big_endian,
+    big_endian_to_int,
+    safe_ord,
+    to_string,
+)
+from ethereum import db
 
 
 def _encode_optimized(item):
@@ -110,7 +115,7 @@ def main():
         st = time.time()
         x = trie.Trie(db.EphemDB())
         for i in range(10000):
-            x.update(str(i), str(i**3))
+            x.update(to_string(i), to_string(i**3))
         print('elapsed', time.time() - st)
         return x.root_hash
 

--- a/ethereum/full_casper/casper_utils.py
+++ b/ethereum/full_casper/casper_utils.py
@@ -330,7 +330,7 @@ def get_dunkle_candidates(chain, state, scan_limit=10):
         descendants = chain.get_descendants(anc)
     else:
         descendants = chain.get_descendants(
-            chain.get_block(chain.db.get('GENESIS_HASH')))
+            chain.get_block(chain.db.get(b'GENESIS_HASH')))
     potential_uncles = [
         x for x in descendants if x not in chain and isinstance(
             x, Block)]

--- a/ethereum/genesis_helpers.py
+++ b/ethereum/genesis_helpers.py
@@ -1,7 +1,14 @@
 from ethereum.state import State
 from ethereum.block import Block, BlockHeader, BLANK_UNCLES_HASH
-from ethereum.utils import decode_hex, big_endian_to_int, encode_hex, \
-    parse_as_bin, parse_as_int, normalize_address
+from ethereum.utils import (
+    decode_hex,
+    big_endian_to_int,
+    encode_hex,
+    parse_as_bin,
+    parse_as_int,
+    normalize_address,
+    to_string,
+)
 from ethereum.config import Env
 from ethereum.consensus_strategy import get_consensus_strategy
 from ethereum.db import OverlayDB, RefcountDB
@@ -67,14 +74,14 @@ def state_from_genesis_declaration(
 
 def initialize_genesis_keys(state, genesis):
     db = state.db
-    db.put('GENESIS_NUMBER', str(genesis.header.number))
-    db.put('GENESIS_HASH', str(genesis.header.hash))
-    db.put('GENESIS_STATE', json.dumps(state.to_snapshot()))
-    db.put('GENESIS_RLP', rlp.encode(genesis))
+    db.put(b'GENESIS_NUMBER', str(genesis.header.number))
+    db.put(b'GENESIS_HASH', to_string(genesis.header.hash))
+    db.put(b'GENESIS_STATE', json.dumps(state.to_snapshot()))
+    db.put(b'GENESIS_RLP', rlp.encode(genesis))
     db.put(b'block:0', genesis.header.hash)
     db.put(b'score:' + genesis.header.hash, "0")
     db.put(b'state:' + genesis.header.hash, state.trie.root_hash)
-    db.put(genesis.header.hash, 'GENESIS')
+    db.put(genesis.header.hash, b'GENESIS')
     db.commit()
 
 

--- a/ethereum/genesis_helpers.py
+++ b/ethereum/genesis_helpers.py
@@ -74,7 +74,7 @@ def state_from_genesis_declaration(
 
 def initialize_genesis_keys(state, genesis):
     db = state.db
-    db.put(b'GENESIS_NUMBER', str(genesis.header.number))
+    db.put(b'GENESIS_NUMBER', to_string(genesis.header.number))
     db.put(b'GENESIS_HASH', to_string(genesis.header.hash))
     db.put(b'GENESIS_STATE', json.dumps(state.to_snapshot()))
     db.put(b'GENESIS_RLP', rlp.encode(genesis))

--- a/ethereum/hybrid_casper/chain.py
+++ b/ethereum/hybrid_casper/chain.py
@@ -1,3 +1,4 @@
+from builtins import range
 import json
 import random
 import time
@@ -589,7 +590,7 @@ class Chain(object):
 
         header = block.header
         hashes = []
-        for i in xrange(max):
+        for i in range(max):
             hash = header.prevhash
             block = self.get_block(hash)
             if block is None:

--- a/ethereum/hybrid_casper/chain.py
+++ b/ethereum/hybrid_casper/chain.py
@@ -80,7 +80,7 @@ class Chain(object):
         self.db.put(b'cp_subtree_score' + b'\x00' * 32, 2/3.)
         self.commit_logs = []
         self.casper_address = self.config['CASPER_ADDRESS']
-        self.db.put(b'GENESIS_NUMBER', str(self.state.block_number))
+        self.db.put(b'GENESIS_NUMBER', to_string(self.state.block_number))
         assert self.state.block_number == self.state.prev_headers[0].number
         if reset_genesis:
             self.genesis = Block(self.state.prev_headers[0], [], [])

--- a/ethereum/messages.py
+++ b/ethereum/messages.py
@@ -334,7 +334,7 @@ class VMExt():
         self.revert = state.revert
         self.transfer_value = state.transfer_value
         self.reset_storage = state.reset_storage
-        self.tx_origin = tx.sender if tx else '\x00' * 20
+        self.tx_origin = tx.sender if tx else b'\x00' * 20
         self.tx_gasprice = tx.gasprice if tx else 0
 
 

--- a/ethereum/new_state.py
+++ b/ethereum/new_state.py
@@ -36,7 +36,7 @@ STATE_DEFAULTS = {
     "gas_used": 0,
     "gas_limit": 3141592,
     "block_number": 0,
-    "block_coinbase": '\x00' * 20,
+    "block_coinbase": b'\x00' * 20,
     "block_difficulty": 1,
     "timestamp": 0,
     "logs": [],

--- a/ethereum/pow/chain.py
+++ b/ethereum/pow/chain.py
@@ -34,7 +34,7 @@ class Chain(object):
                  new_head_cb=None, reset_genesis=False, localtime=None, max_history=1000, **kwargs):
         self.env = env or Env()
         # Initialize the state
-        if 'head_hash' in self.db:  # new head tag
+        if b'head_hash' in self.db:  # new head tag
             self.state = self.mk_poststate_of_blockhash(
                 self.db.get('head_hash'))
             self.state.executing_on_head = True
@@ -81,7 +81,7 @@ class Chain(object):
             assert self.state.block_number == self.state.prev_headers[0].number
         else:
             assert self.state.block_number - 1 == self.state.prev_headers[0].number
-            
+
         if reset_genesis:
             if isinstance(self.state.prev_headers[0], FakeHeader):
                 header = self.state.prev_headers[0].to_block_header()
@@ -103,7 +103,7 @@ class Chain(object):
     def head(self):
         try:
             block_rlp = self.db.get(self.head_hash)
-            if block_rlp in ('GENESIS', b'GENESIS'):
+            if block_rlp == b'GENESIS':
                 return self.genesis
             else:
                 return rlp.decode(block_rlp, Block)
@@ -117,9 +117,9 @@ class Chain(object):
             raise Exception("Block hash %s not found" % encode_hex(blockhash))
 
         block_rlp = self.db.get(blockhash)
-        if block_rlp in ('GENESIS', b'GENESIS'):
+        if block_rlp == b'GENESIS':
             return State.from_snapshot(json.loads(
-                self.db.get('GENESIS_STATE')), self.env)
+                self.db.get(b'GENESIS_STATE')), self.env)
         block = rlp.decode(block_rlp, Block)
 
         state = State(env=self.env)
@@ -142,8 +142,8 @@ class Chain(object):
             except BaseException:
                 break
         if i < header_depth:
-            if state.db.get(b.header.prevhash) == 'GENESIS':
-                jsondata = json.loads(state.db.get('GENESIS_STATE'))
+            if state.db.get(b.header.prevhash) == b'GENESIS':
+                jsondata = json.loads(state.db.get(b'GENESIS_STATE'))
                 for h in jsondata["prev_headers"][:header_depth - i]:
                     state.prev_headers.append(dict_to_prev_header(h))
                 for blknum, uncles in jsondata["recent_uncles"].items():
@@ -158,7 +158,7 @@ class Chain(object):
 
     # Gets the parent block of a given block
     def get_parent(self, block):
-        if block.header.number == int(self.db.get('GENESIS_NUMBER')):
+        if block.header.number == int(self.db.get(b'GENESIS_NUMBER')):
             return None
         return self.get_block(block.header.prevhash)
 
@@ -166,10 +166,10 @@ class Chain(object):
     def get_block(self, blockhash):
         try:
             block_rlp = self.db.get(blockhash)
-            if block_rlp == 'GENESIS':
+            if block_rlp == b'GENESIS':
                 if not hasattr(self, 'genesis'):
                     self.genesis = rlp.decode(
-                        self.db.get('GENESIS_RLP'), sedes=Block)
+                        self.db.get(b'GENESIS_RLP'), sedes=Block)
                 return self.genesis
             else:
                 return rlp.decode(block_rlp, Block)
@@ -312,7 +312,7 @@ class Chain(object):
                 b = block
                 new_chain = {}
                 # Find common ancestor
-                while b.header.number >= int(self.db.get('GENESIS_NUMBER')):
+                while b.header.number >= int(self.db.get(b'GENESIS_NUMBER')):
                     new_chain[b.header.number] = b
                     key = b'block:%d' % b.header.number
                     orig_at_height = self.db.get(
@@ -320,7 +320,7 @@ class Chain(object):
                     if orig_at_height == b.header.hash:
                         break
                     if b.prevhash not in self.db or self.db.get(
-                            b.prevhash) == 'GENESIS':
+                            b.prevhash) == b'GENESIS':
                         break
                     b = self.get_parent(b)
                 replace_from = b.header.number
@@ -401,7 +401,9 @@ class Chain(object):
                      (block.number, encode_hex(block.hash[:4]), encode_hex(block.prevhash[:4])))
             return False
         self.add_child(block)
-        self.db.put('head_hash', self.head_hash)
+        
+        self.db.put(b'head_hash', self.head_hash)
+
         self.db.put(block.hash, rlp.encode(block))
         self.db.put(b'changed:' + block.hash,
                     b''.join([k.encode() if not is_string(k) else k for k in list(changed.keys())]))
@@ -463,7 +465,7 @@ class Chain(object):
 
     def get_chain(self, frm=None, to=2**63 - 1):
         if frm is None:
-            frm = int(self.db.get('GENESIS_NUMBER')) + 1
+            frm = int(self.db.get(b'GENESIS_NUMBER')) + 1
         chain = []
         for i in itertools.islice(itertools.count(), frm, to):
             h = self.get_blockhash_by_number(i)

--- a/ethereum/pow/chain.py
+++ b/ethereum/pow/chain.py
@@ -76,11 +76,6 @@ class Chain(object):
 
         initialize(self.state)
         self.new_head_cb = new_head_cb
-        
-        if self.state.block_number == 0:
-            assert self.state.block_number == self.state.prev_headers[0].number
-        else:
-            assert self.state.block_number - 1 == self.state.prev_headers[0].number
 
         if reset_genesis:
             if isinstance(self.state.prev_headers[0], FakeHeader):
@@ -92,6 +87,9 @@ class Chain(object):
             initialize_genesis_keys(self.state, self.genesis)
         else:
             self.genesis = self.get_block_by_number(0)
+
+        assert self.state.block_number == self.state.prev_headers[0].number
+
         self.head_hash = self.state.prev_headers[0].hash
         self.time_queue = []
         self.parent_queue = {}

--- a/ethereum/pow/chain.py
+++ b/ethereum/pow/chain.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import json
 import random
 import time
@@ -502,16 +503,15 @@ class Chain(object):
         return self.env.db
 
     # Get blockhashes starting from a hash and going backwards
-    def get_blockhashes_from_hash(self, hash, max):
-        block = self.get_block(hash)
+    def get_blockhashes_from_hash(self, blockhash, max_num):
+        block = self.get_block(blockhash)
         if block is None:
             return []
 
         header = block.header
         hashes = []
-        for i in xrange(max):
-            hash = header.prevhash
-            block = self.get_block(hash)
+        for i in range(max_num):
+            block = self.get_block(header.prevhash)
             if block is None:
                 break
             header = block.header

--- a/ethereum/pow/ethash.py
+++ b/ethereum/pow/ethash.py
@@ -78,8 +78,8 @@ def hashimoto(header, nonce, full_size, dataset_lookup):
     for i in range(0, len(mix), 4):
         cmix.append(fnv(fnv(fnv(mix[i], mix[i + 1]), mix[i + 2]), mix[i + 3]))
     return {
-        "mix digest": serialize_hash(cmix),
-        "result": serialize_hash(sha3_256(s + cmix))
+        b'mix digest': serialize_hash(cmix),
+        b'result': serialize_hash(sha3_256(s + cmix))
     }
 
 

--- a/ethereum/pow/ethpow.py
+++ b/ethereum/pow/ethpow.py
@@ -36,7 +36,7 @@ else:
     raise Exception("invalid ethash library set")
 
 TT64M1 = 2**64 - 1
-cache_seeds = ['\x00' * 32]
+cache_seeds = [b'\x00' * 32]
 cache_by_seed = OrderedDict()
 cache_by_seed.max_items = 10
 
@@ -124,9 +124,9 @@ def mine(block_number, difficulty, mining_hash, start_nonce=0, rounds=1000):
             utils.int_to_big_endian(
                 (nonce + i) & TT64M1), 8)
         o = hashimoto_light(block_number, cache, mining_hash, bin_nonce)
-        if o[b"result"] <= target:
-            log.debug("nonce found")
+        if o[b'result'] <= target:
+            log.debug('nonce found: {}'.format(bin_nonce))
             assert len(bin_nonce) == 8
-            assert len(o[b"mix digest"]) == 32
-            return bin_nonce, o[b"mix digest"]
+            assert len(o[b'mix digest']) == 32
+            return bin_nonce, o[b'mix digest']
     return None, None

--- a/ethereum/snapshot.py
+++ b/ethereum/snapshot.py
@@ -74,7 +74,7 @@ def create_account_snapshot(env, rlpdata):
     storage_trie = SecureTrie(Trie(env.db, account.storage))
     storage = dict()
     for k, v in storage_trie.iter_branch():
-        storage[encode_hex(k.lstrip('\x00') or '\x00')] = encode_hex(v)
+        storage[encode_hex(k.lstrip(b'\x00') or b'\x00')] = encode_hex(v)
     return {
         'nonce': snapshot_form(account.nonce),
         'balance': snapshot_form(account.balance),
@@ -109,7 +109,7 @@ def load_snapshot(chain, snapshot):
     trie = load_state(chain.env, snapshot['alloc'])
     assert trie.root_hash == base_header.state_root
     chain.state.trie = trie
-    chain.env.db.put('score:' + base_header.hash, snapshot['chainDifficulty'])
+    chain.env.db.put(b'score:' + base_header.hash, snapshot['chainDifficulty'])
     chain.env.db.commit()
 
     print("Start loading recent blocks from snapshot")

--- a/ethereum/tests/hybrid_casper/test_casper.py
+++ b/ethereum/tests/hybrid_casper/test_casper.py
@@ -63,7 +63,7 @@ assert casper.get_consensus_messages__ancestry_hash_justified(_e, _a)
 assert casper.get_main_hash_justified()
 print("Prepare message processed")
 try:
-    casper.prepare(mk_prepare(0, 1, '\x35' * 32, '\x00' * 32, 0, '\x00' * 32, t.k0))
+    casper.prepare(mk_prepare(0, 1, b'\x35' * 32, b'\x00' * 32, 0, b'\x00' * 32, t.k0))
     success = True
 except:
     success = False

--- a/ethereum/tests/test_chain.py
+++ b/ethereum/tests/test_chain.py
@@ -14,7 +14,7 @@ from ethereum.state import State
 from ethereum.block import Block
 from ethereum.consensus_strategy import get_consensus_strategy
 from ethereum.genesis_helpers import mk_basic_state
-
+from ethereum.tools import tester
 from ethereum.slogging import get_logger
 logger = get_logger()
 
@@ -373,6 +373,23 @@ def test_genesis_from_state_snapshot():
     assert new_chain.state.block_difficulty == state.block_difficulty
     assert new_chain.head.number == state.block_number
 
+
+def test_get_blockhashes_from_hash():
+    test_chain = tester.Chain()
+    test_chain.mine(5)
+
+    blockhashes = test_chain.chain.get_blockhashes_from_hash(
+         test_chain.chain.get_block_by_number(5).hash,
+         2,
+    )
+    assert len(blockhashes) == 2
+
+
+def test_get_blockhash_by_number():
+    test_chain = tester.Chain()
+    test_chain.mine(2)
+
+    test_chain.chain.get_blockhash_by_number(2) == test_chain.chain.head.hash
 
 # TODO ##########################################
 #

--- a/ethereum/transactions.py
+++ b/ethereum/transactions.py
@@ -98,7 +98,7 @@ class Transaction(rlp.Serializable):
                 if self.r >= secpk1n or self.s >= secpk1n or self.r == 0 or self.s == 0:
                     raise InvalidTransaction("Invalid signature values!")
                 pub = ecrecover_to_pub(sighash, vee, self.r, self.s)
-                if pub == b"\x00" * 64:
+                if pub == b'\x00' * 64:
                     raise InvalidTransaction(
                         "Invalid signature (zero privkey cannot sign)")
                 self._sender = utils.sha3(pub)[-20:]


### PR DESCRIPTION
### - What I did
1. Improve python3 compatibility
2. An adjustment of https://github.com/ethereum/pyethereum/commit/91342a0430119d3884ac7d6bf4078fcf38e401fa because I found `pyethapp` can’t run on the old code, hope @joeykrug could help to check if this patch works for your case too.

### - How I did it
1. Using `to_string(data)` instead most `str(data)` function. Note that `to_string(data)` returns `bytes` for both Python2 and Python3.
2. Added the missing `b` before binary string
3. Modified the assertion of `state.block_number` and `state.prev_headers[0].number`


Related issue: https://github.com/ethereum/pyethereum/issues/442

### - Cute Animal Picture
![bear2](https://user-images.githubusercontent.com/9263930/31627584-62fc0f14-b273-11e7-8304-6b2561938954.jpg)
