### PR TITLE
vm: fix indentation

### DIFF
--- a/ethereum/vm.py
+++ b/ethereum/vm.py
@@ -235,10 +235,10 @@ def vm_trace(ext, msg, compustate, opcode, pushcache, tracer=log_vm_op):
     trace_data['steps'] = compustate.steps
     trace_data['depth'] = msg.depth
     if op[:4] == 'PUSH':
-	if sys.version_info.major == 2:
-        	print repr(pushcache)
-	else:
-		print(repr(pushcache))
+        if sys.version_info.major == 2:
+                print repr(pushcache)
+        else:
+            print(repr(pushcache))
 
         trace_data['pushvalue'] = pushcache[compustate.prev_pc]
     tracer.trace('vm', op=op, **trace_data)

--- a/ethereum/vm.py
+++ b/ethereum/vm.py
@@ -235,11 +235,7 @@ def vm_trace(ext, msg, compustate, opcode, pushcache, tracer=log_vm_op):
     trace_data['steps'] = compustate.steps
     trace_data['depth'] = msg.depth
     if op[:4] == 'PUSH':
-        if sys.version_info.major == 2:
-                print repr(pushcache)
-        else:
-            print(repr(pushcache))
-
+        print(repr(pushcache))
         trace_data['pushvalue'] = pushcache[compustate.prev_pc]
     tracer.trace('vm', op=op, **trace_data)
     compustate.steps += 1
@@ -263,7 +259,8 @@ def vm_execute(ext, msg, code):
 
     # For tracing purposes
     op = None
-
+    _prevop = None
+    steps = 0
     while compustate.pc < codelen:
 
         opcode = safe_ord(code[compustate.pc])


### PR DESCRIPTION
An issue from https://github.com/ethereum/pyethereum/pull/813

```
Traceback (most recent call last):
  File "run_statetest.py", line 13, in <module>
    from ethereum.messages import apply_transaction
  File "/usr/lib/python3.6/site-packages/ethereum-2.1.0-py3.6.egg/ethereum/messages.py", line 19, in <module>
    from ethereum import vm
  File "/usr/lib/python3.6/site-packages/ethereum-2.1.0-py3.6.egg/ethereum/vm.py", line 238
    if sys.version_info.major == 2:
                                  ^
TabError: inconsistent use of tabs and spaces in indentation
``` 