### PR TITLE
Fixed Chain.process_time_queue and added test

### DIFF
--- a/ethereum/hybrid_casper/chain.py
+++ b/ethereum/hybrid_casper/chain.py
@@ -207,7 +207,7 @@ class Chain(object):
     def process_time_queue(self, new_time=None):
         self.localtime = time.time() if new_time is None else new_time
         i = 0
-        while i < len(self.time_queue) and self.time_queue[i].timestamp <= new_time:
+        while i < len(self.time_queue) and self.time_queue[i].timestamp <= self.localtime:
             log.info('Adding scheduled block')
             pre_len = len(self.time_queue)
             self.add_block(self.time_queue.pop(i))

--- a/ethereum/pow/chain.py
+++ b/ethereum/pow/chain.py
@@ -248,7 +248,7 @@ class Chain(object):
         self.localtime = time.time() if new_time is None else new_time
         i = 0
         while i < len(
-                self.time_queue) and self.time_queue[i].timestamp <= new_time:
+                self.time_queue) and self.time_queue[i].timestamp <= self.localtime:
             log.info('Adding scheduled block')
             pre_len = len(self.time_queue)
             self.add_block(self.time_queue.pop(i))

--- a/ethereum/tests/test_chain.py
+++ b/ethereum/tests/test_chain.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 import ethereum.messages as messages
 import ethereum.transactions as transactions
@@ -373,6 +374,39 @@ def test_genesis_from_state_snapshot():
     assert new_chain.state.block_difficulty == state.block_difficulty
     assert new_chain.head.number == state.block_number
 
+
+def test_process_time_queue():
+    """
+    Test Chain.process_time_queue
+    """
+    # Arrange testing data blk0
+    k, v, k2, v2 = accounts()
+    chain = Chain({}, difficulty=1)
+    blk0 = mine_on_chain(chain, coinbase=decode_hex('0' * 40))
+    hash0 = chain.head.hash
+    blk1 = mine_on_chain(chain, coinbase=decode_hex('0' * 40))
+    hash1 = chain.head.hash
+
+    # Act on chain2
+    chain2 = Chain({}, difficulty=1)
+    chain2.time_queue.insert(0, blk0)
+    assert len(chain2.time_queue) == 1
+
+    # Not reach time threshold, process_time_queue doesn't call add_block
+    chain2.process_time_queue(new_time=0)
+    assert len(chain2.time_queue) == 1
+    assert chain2.head.hash != chain.head.hash
+
+    # Reach time threshold, process_time_queue calls add_block
+    chain2.process_time_queue(new_time=time.time() + 10)
+    assert len(chain2.time_queue) == 0
+    assert chain2.head.hash == hash0
+
+    # If new_time is None, use time.time()
+    chain2.time_queue.insert(1, blk1)
+    chain2.process_time_queue()
+    assert len(chain2.time_queue) == 0
+    assert chain2.head.hash == hash1
 
 # TODO ##########################################
 #


### PR DESCRIPTION
### - What I did
1. Fixed `Chain.process_time_queue(new_time=None)`. If we call `Chain.process_time_queue()`, the old code uses `NoneType` to compare the block timestamp and returns error in Python3:
```
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```
2. IMO it's more efficient to use the updated`self.local_time` to check if the block can be added.


### - How I did it
1. Use the updated `self.local_time` to compare with time queue item
2. Add `test_process_time_queue`

### - How to verify it
```
pytest ethereum/tests/test_chain.py::test_process_time_queue
```

### - Description for the changelog
Fixed Chain.process_time_queue and added test

### - Cute Animal Picture
![leopardcat](https://user-images.githubusercontent.com/9263930/31702009-b5d9deec-b399-11e7-9850-3d14a53c06a6.jpg)