### PR TITLE
Use `list` rather than `set` in setup.py - currently broken with setuptools v38.0.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 # requirements
-install_requires = set(x.strip() for x in open('requirements.txt'))
+install_requires = list(x.strip() for x in open('requirements.txt'))
 install_requires_replacements = {
     'https://github.com/ethereum/ethash/tarball/master': 'pyethash',
 }
@@ -14,7 +14,7 @@ install_requires = [
         r, r) for r in install_requires]
 
 # dev requirements
-tests_require = set(x.strip() for x in open('dev_requirements.txt'))
+tests_require = list(x.strip() for x in open('dev_requirements.txt'))
 
 # dependency links
 dependency_links = []


### PR DESCRIPTION
* As of setuptools v38.0.0 it is no longer valid to use unordered
sequences (sets or dicts) for install_requires or tests_require.

Reference:
https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v3800

Fixes this error when installing with setuptools v38.1.0:
```
Complete output from command python setup.py egg_info:
error in ethereum setup command: 'tests_require' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed
```

Developers should maintain requirements.txt and dev-requirements.txt. There is no need to deduplicate it in `setup.py`.