### PR TITLE
Catch the correct exception on python 3

### DIFF
--- a/ethereum/tools/_solidity.py
+++ b/ethereum/tools/_solidity.py
@@ -98,7 +98,7 @@ def solc_parse_output(compiler_output):
             # decoding can fail if the compiled contract has unresolved symbols
             try:
                 value['bin'] = decode_hex(value['bin_hex'])
-            except TypeError:
+            except (TypeError, ValueError):
                 pass
 
     for json_data in ('abi', 'devdoc', 'userdoc'):


### PR DESCRIPTION
The parsing of the `solc` output can fail if unresolved symbols are included in the compiled contract. This throws an `TypeError` under python 2 but a `ValueError` under python 3.

This PR adapts the code to work under both py2 and py3.