### PR TITLE
Add libyaml-cpp-dev to Ubuntu/Debian installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://github.com/ethereum/pyethapp
 ## Installation:
 
 ```bash
-sudo apt-get install libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev
+sudo apt-get install libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev libyaml-cpp-dev
 git clone https://github.com/ethereum/pyethereum/
 cd pyethereum
 python setup.py install


### PR DESCRIPTION
Otherwise I received the following error:

```
Running PyYAML-3.12/setup.py -q bdist_egg --dist-dir /tmp/easy_install-jnm6__7s/PyYAML-3.12/egg-dist-tmp-uocwz8if
build/temp.linux-x86_64-3.5/check_libyaml.c:2:18: fatal error: yaml.h: No such file or directory
compilation terminated.
```