### PR TITLE
must check right distribution name not pyethapp see issue #821

### DIFF
--- a/ethereum/__init__.py
+++ b/ethereum/__init__.py
@@ -17,11 +17,11 @@ GIT_DESCRIBE_RE = re.compile(
 
 __version__ = None
 try:
-    _dist = get_distribution('pyethapp')
+    _dist = get_distribution('ethereum')
     # Normalize case for Windows systems
     dist_loc = os.path.normcase(_dist.location)
     here = os.path.normcase(__file__)
-    if not here.startswith(os.path.join(dist_loc, 'pyethapp')):
+    if not here.startswith(os.path.join(dist_loc, 'ethereum')):
         # not installed, but there is another version that *is*
         raise DistributionNotFound
     __version__ = _dist.version


### PR DESCRIPTION
**Problem**: `__version__` is never set as identified by @drandreaskrueger in issue #821 


**Analysis**:  `pyethereum` always checks `pyethapp` distribution for `__version__`  however if python site local or global has not `pyethapp` installed, then `undefined` is set.


**Solution**: Check correct distribution `ethereum` instead of `pyethapp`

**Test**:

Platform: ubuntu 16.04

__2.7.12__
```
python2 -c "import ethereum; print(ethereum.__version__)"
2.3.0
```

__3.5.2__
```
python3 -c "import ethereum; print(ethereum.__version__)"
2.3.0
```
