### PR TITLE
Add Vyper as a test option as well.

### DIFF
--- a/ethereum/tools/tester.py
+++ b/ethereum/tools/tester.py
@@ -49,6 +49,12 @@ try:
 except (ImportError, TypeError):
     pass
 
+try:
+    from vyper import compiler
+    languages['vyper'] = compiler
+except (ImportError, TypeError):
+    pass
+
 
 class TransactionFailed(Exception):
     pass


### PR DESCRIPTION
https://github.com/ethereum/vyper was renamed from 'Viper' to 'Vyper'. We are in the process of doing the full renaming of the vyper module as well. 

Just patching the tester like so - will for the interim allow both viper & vyper support - if someone is using an older checkout from master.  Alternatively  I can also create the full patch for 'vyper' in the other parts of of the develop branch - and once viper is fully renamed it just merges.

Let me know what's easiest ;)