### PR TITLE
remove solc_wrapper deprecation warning

### DIFF
--- a/ethereum/tools/_solidity.py
+++ b/ethereum/tools/_solidity.py
@@ -389,8 +389,6 @@ class Solc(object):
     @staticmethod
     def _code_or_path(sourcecode, path, contract_name,
                       libraries, combined, extra_args):
-        warnings.warn(
-            'solc_wrapper is deprecated, please use the functions compile_file or compile_code')
 
         if sourcecode and path:
             raise ValueError('sourcecode and path are mutually exclusive.')


### PR DESCRIPTION
This warning was introduced in https://github.com/ethereum/pyethereum/commit/6a5cedd3621a55dd3aefce8faafc895a7fbdc046#diff-b311c7337c84d59a052b80af8792b7c2R309

however, solc_wrapper is used by pyethereum.tester. I asked @hackaugusto about it and here is his response:

> I added this a while back when I used to work  more frequently with the pyethereum codebase. At the time I'm not really involved with the project, so I would ask the current maintainers if they plan to remove this interface or not, if not then to remove the warning.
