### PR TITLE
Regex on Line 127 in _solidity.py

### DIFF
--- a/ethereum/tools/_solidity.py
+++ b/ethereum/tools/_solidity.py
@@ -123,7 +123,7 @@ def solc_parse_output(compiler_output):
 
 def compiler_version():
     """ Return the version of the installed solc. """
-    version_info = subprocess.check_output(['solc', '--version'])
+    version_info = subprocess.check_output(['solc', '--version'], stderr=subprocess.STDOUT)
     match = re.search(b'^Version: ([0-9a-z.-]+)', version_info, re.MULTILINE)
 
     if match:

--- a/ethereum/tools/_solidity.py
+++ b/ethereum/tools/_solidity.py
@@ -124,7 +124,7 @@ def solc_parse_output(compiler_output):
 def compiler_version():
     """ Return the version of the installed solc. """
     version_info = subprocess.check_output(['solc', '--version'])
-    match = re.search(b'^Version: ([0-9a-z.-]+)/', version_info, re.MULTILINE)
+    match = re.search(b'^Version: ([0-9a-z.-]+)', version_info, re.MULTILINE)
 
     if match:
         return match.group(1)


### PR DESCRIPTION
Hi, I had a feeling that the added '/' in the regex was messing up with returning the solidity compiler version, because for me it kept returning `None`, however removing that made it better. I'm presuming that by adding the '/' it searches the base text for a literal match of the '/', and can't tell what other function it performs. Please do check.