### PR TITLE
hack to set rlp==1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,10 @@ install:
   - travis_retry pip install flake8
   - travis_retry python setup.py install
   - travis_retry pip install -r dev_requirements.txt
+  # hack to override rlp=0.6.0 pulled in from vyper and eth-tester
+  - pip install rlp==1.0.1
 script:
+  - pip freeze
   # XXX: For now we're only performing minimal CI checks as most tests are
   # broken. Tests will be individually added here as they're fixed.
   - make lint-minimal


### PR DESCRIPTION
In CI, force `rlp==1.0.1`. This produces the following warnings:

```
py-evm 0.2.0a12 has requirement rlp<1.0.0,>=0.4.7, but you'll have rlp 1.0.1 which is incompatible.
eth-tester 0.1.0b21 has requirement rlp<1.0.0,>=0.6.0, but you'll have rlp 1.0.1 which is incompatible.
```

but the packages still work fine.

Will be removed when vyper supports `rlp >= 1`.