### PR TITLE
Fix signing transactions with network_id

### DIFF
--- a/ethereum/tests/test_chain.py
+++ b/ethereum/tests/test_chain.py
@@ -95,11 +95,11 @@ def test_mining(db):
 
 
 @pytest.fixture(scope="module")
-def get_transaction(gasprice=0, nonce=0):
+def get_transaction(gasprice=0, nonce=0, network_id=None):
     k, v, k2, v2 = accounts()
     tx = transactions.Transaction(
         nonce, gasprice, startgas=100000,
-        to=v2, value=utils.denoms.finney * 10, data=b'').sign(k)
+        to=v2, value=utils.denoms.finney * 10, data=b'').sign(k, network_id=network_id)
     return tx
 
 
@@ -430,6 +430,10 @@ def test_get_blockhash_by_number():
     test_chain.mine(2)
 
     test_chain.chain.get_blockhash_by_number(2) == test_chain.chain.head.hash
+
+def test_sign_with_network_id():
+    tx = get_transaction(network_id=66)
+    assert tx.network_id == 66
 
 
 # TODO ##########################################

--- a/ethereum/transactions.py
+++ b/ethereum/transactions.py
@@ -132,10 +132,10 @@ class Transaction(rlp.Serializable):
 
         v, r, s = ecsign(rawhash, key)
         if network_id is not None:
-            self.v += 8 + network_id * 2
+            v += 8 + network_id * 2
 
         ret = self.copy(
-            v=v,r=r,s=s
+            v=v, r=r, s=s
         )
         ret._sender = utils.privtoaddr(key)
         return ret


### PR DESCRIPTION
The changes made to transaction signing in 428395bae120397423f40e8df374e67f5d739f09 missed the case where network_id was passed in, causing an error as the `self.v` argument immutable, and even if it wasn't would fail as `self.v` is not `v` at this point.

Fixed the issue, and added a test to check network_id is set correctly when signing